### PR TITLE
Add --fallback-url argument

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -82,6 +82,10 @@ pypi-server -h will print a detailed usage message::
       disable redirect to real PyPI index for packages not found in the
       local index
 
+    --fallback-url FALLBACK_URL
+      for packages not found in the local index, this URL will be used to
+      redirect to (default: http://pypi.python.org/simple)
+
     --server METHOD
       use METHOD to run the server. Valid values include paste,
       cherrypy, twisted, gunicorn, gevent, wsgiref, auto. The

--- a/pypiserver/__init__.py
+++ b/pypiserver/__init__.py
@@ -1,5 +1,5 @@
-__version_info__ = (0, 6, 1)
-version = __version__ = "0.6.1"
+__version_info__ = (0, 6, 2, 'dev')
+version = __version__ = "0.6.2dev"
 
 
 def app(root=None,

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -74,3 +74,14 @@ def test_root_r(main):
 def test_root_multiple(main):
     pytest.raises(SystemExit, main, [".", "."])
     pytest.raises(SystemExit, main, ["-r", ".", "."])
+
+
+def test_fallback_url(main):
+    main(["--fallback-url", "http://pypi.mirror/simple"])
+    assert main.app.module.config.fallback_url == "http://pypi.mirror/simple"
+
+
+def test_fallback_url_default(main):
+    main([])
+    assert main.app.module.config.fallback_url == \
+        "http://pypi.python.org/simple"


### PR DESCRIPTION
Hi,

This PR adds an argument called `--callback-url` to make the `fallback_url` configurable. This is useful to point it to a mirror or proxy.

Please let me know if you have any questions, I'm happy to answer them!

Cheers,
Orne
