### PR TITLE
Add 'console_scripts' section to 'entry_points', so 'pypi-server.exe' will be created on Windows.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,10 @@ import sys, os
 
 try:
     from setuptools import setup
-    extra = dict(entry_points={'paste.app_factory': ['main=pypiserver:paste_app_factory']})
+    extra = dict(entry_points={
+            'paste.app_factory': ['main=pypiserver:paste_app_factory'],
+            'console_scripts': ['pypi-server=pypiserver.core:main']
+            })
 except ImportError:
     from distutils.core import setup
     extra = dict()


### PR DESCRIPTION
Otherwise, I have to write `python <path to scripts folder>\pypi-server <arguments>` each time. Creating a `cmd` file might be a workaround, but the `console_scripts` way is so much simpler.
