### PR TITLE
Do not overwrite existing files

### DIFF
--- a/pypiserver/_app.py
+++ b/pypiserver/_app.py
@@ -110,7 +110,9 @@ def update():
     if "/" in content.filename:
         raise HTTPError(400, output="bad filename")
 
-    packages.store(content.filename, content.value)
+    if not packages.store(content.filename, content.value):
+        raise HTTPError(409, output="file already exists")
+
 
     return ""
 

--- a/pypiserver/core.py
+++ b/pypiserver/core.py
@@ -68,10 +68,14 @@ class pkgset(object):
     def store(self, filename, data):
         assert "/" not in filename
         dest_fn = os.path.join(self.root, filename)
-        dest_fh = open(dest_fn, "wb")
+        if not os.path.exists(dest_fn):
+            dest_fh = open(dest_fn, "wb")
 
-        dest_fh.write(data)
-        dest_fh.close()
+            dest_fh.write(data)
+            dest_fh.close()
+            return True
+
+        return False
 
 
 def usage():


### PR DESCRIPTION
I quickly implemented a way to not overwrite existing tarball to force developpers increment their version number when they create a new release.
