### PR TITLE
replace os.spawnlp with subprocess.call

### DIFF
--- a/pypiserver/manage.py
+++ b/pypiserver/manage.py
@@ -1,6 +1,7 @@
 
 import sys, os
 from pypiserver import core
+from subprocess import call
 
 if sys.version_info >= (3, 0):
     from xmlrpc.client import Server
@@ -134,4 +135,4 @@ def update(pkgset, destdir=None, dry_run=False, stable_only=True):
 
         sys.stdout.write("%s\n\n" % (" ".join(cmd),))
         if not dry_run:
-            os.spawnlp(os.P_WAIT, cmd[0], *cmd)
+            call(cmd)


### PR DESCRIPTION
Fixes #26  

http://docs.python.org/2/library/subprocess.html#replacing-the-os-spawn-family
