### PR TITLE
Added support for verify, doc_upload and remove_pkg actions

### DIFF
--- a/pypiserver/_app.py
+++ b/pypiserver/_app.py
@@ -151,7 +151,7 @@ def update():
         return ""
 
     if action != "file_upload":
-        raise HTTPError(400, output="actions other than file_upload/submit, not supported")
+        raise HTTPError(400, output="action not supported: %s" % action)
 
     try:
         content = request.files['content']


### PR DESCRIPTION
I'm experimenting with using `pypiserver` for my testing of distlib, and the standalone option is very handy. I added support for actions which I needed in my testing:
- `verify` (does nothing, but returns success)
- `doc_upload` (checks that a valid zip file is uploaded, and that it has an `index.html`)
- `remove_pkg` (needed since tests run repeatedly, to avoid 409 errors on file_upload actions).

You may find these useful, so I thought I'd share. I haven't added tests, as I'm not that familiar with `py.test`, but I noticed that there don't seem to be tests for POST operations anyway (e.g. `file_upload`).
