### PR TITLE
Show names with hyphens instead of underscores on the "/simple" listing page

### DIFF
--- a/pypiserver/_app.py
+++ b/pypiserver/_app.py
@@ -174,7 +174,7 @@ def simpleindex_redirect():
 
 @app.route("/simple/")
 def simpleindex():
-    prefixes = sorted(set([x.pkgname for x in packages() if x.pkgname]))
+    prefixes = sorted(set([x.pkgname.replace("_", "-") for x in packages() if x.pkgname]))
     res = ["<html><head><title>Simple Index</title></head><body>\n"]
     for x in prefixes:
         res.append('<a href="%s/">%s</a><br>\n' % (x, x))


### PR DESCRIPTION
On the "/simple" listing page, names with hyphens and names with
underscores are currently both pointing to the same set of files due to
the use of `pypiserver.core.normalize_pkgname`. Make a change to display
only names with hyphens on the "/simple" listing page to avoid
duplication.
