### PR TITLE
Remove duplicates from "/simple" index page

### DIFF
--- a/pypiserver/_app.py
+++ b/pypiserver/_app.py
@@ -10,9 +10,10 @@ if sys.version_info >= (3, 0):
 else:
     from urlparse import urljoin
 
+from collections import defaultdict
 from bottle import static_file, redirect, request, HTTPError, Bottle
 from pypiserver import __version__
-from pypiserver.core import listdir, find_packages, store
+from pypiserver.core import listdir, find_packages, store, normalize_pkgname
 
 packages = None
 
@@ -174,7 +175,24 @@ def simpleindex_redirect():
 
 @app.route("/simple/")
 def simpleindex():
-    prefixes = sorted(set([x.pkgname.replace("_", "-") for x in packages() if x.pkgname]))
+    package_groups = defaultdict(list)
+    for x in packages():
+        if x.pkgname:
+            package_groups[normalize_pkgname(x.pkgname)].append(
+                (x.pkgname, x.relfn))
+
+    prefixes = []
+    for package_group in package_groups.itervalues():
+        for pkgname, relfn in package_group:
+            if relfn.endswith('.egg'):
+                backup_name = pkgname
+            else:
+                prefixes.append(pkgname)
+                break
+        else:
+            prefixes.append(backup_name)
+    prefixes = sorted(prefixes)
+
     res = ["<html><head><title>Simple Index</title></head><body>\n"]
     for x in prefixes:
         res.append('<a href="%s/">%s</a><br>\n' % (x, x))

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -175,3 +175,29 @@ def test_root_no_relative_paths(testpriv):
     resp = testpriv.get("/priv/")
     hrefs = [x["href"] for x in resp.html("a")]
     assert hrefs == ['/priv/packages/', '/priv/simple/', 'http://pypi.python.org/pypi/pypiserver']
+
+
+def test_simple_index_list_no_duplicates(root, testapp):
+    root.join("foo-bar-1.0.tar.gz").write("")
+    root.join("foo_bar-1.0-py2.7.egg").write("")
+
+    resp = testapp.get("/simple/")
+    assert len(resp.html("a")) == 1
+
+
+def test_simple_index_list_name_with_underscore(root, testapp):
+    root.join("foo_bar-1.0.tar.gz").write("")
+    root.join("foo_bar-1.0-py2.7.egg").write("")
+
+    resp = testapp.get("/simple/")
+    assert len(resp.html("a")) == 1
+    hrefs = [x["href"] for x in resp.html("a")]
+    assert hrefs == ["foo_bar/"]
+
+
+def test_simple_index_egg_and_tarball(root, testapp):
+    root.join("foo-bar-1.0.tar.gz").write("")
+    root.join("foo_bar-1.0-py2.7.egg").write("")
+
+    resp = testapp.get("/simple/foo-bar")
+    assert len(resp.html("a")) == 2


### PR DESCRIPTION
After uploading both an egg file and a source file for packages with a
hyphen in the name, the "/simple" index lists two entries-- one with
hyphens and one with underscores. For example, if an egg and tarball for
MySQL-python are uploaded, the "/simple" index page lists
"MySQL-python"" and "MySQL_python"".

Some example packages that exhibit this behavior:
- MySQL-python
- Flask-Actions
- unittest-xml-reporting
- nose-exclude

Note that http://pypi.python.org/simple does not list both names with
hyphens and names with underscores, so this change brings pypiserver
closer to the behavior of http://pypi.python.org/simple.

We use the pypiserver project at our company and are interested in
seeing this fixed. I noticed the first fix I submitted didn't properly
handle packages with underscores in their names, so I have re-worked the
fix to handle this.

Thanks,
Eliot
