### PR TITLE
Fix guessing of package name and version.

### DIFF
--- a/pypiserver/core.py
+++ b/pypiserver/core.py
@@ -47,9 +47,17 @@ _archive_suffix_rx = re.compile(r"(\.zip|\.tar\.gz|\.tgz|\.tar\.bz2|-py[23]\.\d-
 
 def guess_pkgname_and_version(path):
     path = os.path.basename(path)
-    pkgname = '-'.join(re.split(r'-(?=\d+)', path)[:-1])
-    version = path[len(pkgname) + 1:]
-    version = _archive_suffix_rx.sub("", version)
+    path = _archive_suffix_rx.sub('', path)
+    if '-' not in path:
+        pkgname, version = path, ''
+    elif path.count('-') == 1:
+        pkgname, version = path.split('-', 1)
+    elif '.' not in path:
+        pkgname, version = path.rsplit('-', 1)
+    else:
+        parts = re.split(r'-(?=(?i)v?\d+[\.a-z])', path)
+        pkgname = '-'.join(parts[:-1])
+        version = parts[-1]
     return pkgname, version
 
 

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -17,7 +17,21 @@ files = [
     ("pep8-0.6.0.zip", "pep8", "0.6.0"),
     ("pytz-2012b.zip", "pytz", "2012b"),
     ("ABC12-34_V1X-1.2.3.zip", "ABC12-34_V1X", "1.2.3"),
-    ("A100-200-XYZ-1.2.3.zip", "A100-200-XYZ", "1.2.3")]
+    ("A100-200-XYZ-1.2.3.zip", "A100-200-XYZ", "1.2.3"),
+    ("flup-1.0.3.dev-20110405.tar.gz", "flup", "1.0.3.dev-20110405"),
+    ("package-1.0.0-alpha.1.zip", "package", "1.0.0-alpha.1"),
+    ("package-1.3.7+build.11.e0f985a.zip", "package", "1.3.7+build.11.e0f985a"),
+    ("package-v1.8.1.301.ga0df26f.zip", "package", "v1.8.1.301.ga0df26f"),
+    ("package-2013.02.17.dev123.zip", "package", "2013.02.17.dev123"),
+    ("package-20000101.zip", "package", "20000101"),
+    ("flup-123-1.0.3.dev-20110405.tar.gz", "flup-123", "1.0.3.dev-20110405"),
+    ("package-123-1.0.0-alpha.1.zip", "package-123", "1.0.0-alpha.1"),
+    ("package-123-1.3.7+build.11.e0f985a.zip", "package-123", "1.3.7+build.11.e0f985a"),
+    ("package-123-v1.8.1.301.ga0df26f.zip", "package-123", "v1.8.1.301.ga0df26f"),
+    ("package-123-2013.02.17.dev123.zip", "package-123", "2013.02.17.dev123"),
+    ("package-123-20000101.zip", "package-123", "20000101"),
+    ("package.zip", "package", ""),
+]
 
 
 @pytest.mark.parametrize(("filename", "pkgname", "version"), files)


### PR DESCRIPTION
Hi,

We had a problem where some of our packages could not be installed via pip from our pypiserver instance. This occurred after upgrading from 0.5.0 to 1.1.2 and it is due to a change introduced in 0.5.2. I have created a patch for this which passes all existing tests and currently works well for us.

The fix in commit 7f97612 for supporting the package naming used by the pytz module caused a regression if the package name contained a dash followed by a number. We fix this by splitting on all dashes followed by numbers and recreating the package name from all components but the last.

Cheers,

Nick

CC: @wimpr1m
