### PR TITLE
use the same mimetypes as pypi does

### DIFF
--- a/pypiserver/_app.py
+++ b/pypiserver/_app.py
@@ -230,7 +230,15 @@ def server_static(filename):
     for x in entries:
         f = x.relfn.replace("\\", "/")
         if f == filename:
-            return static_file(filename, root=x.root)
+            # pip>=1.5 respects the Content Encoding header, do not send it, as
+            # it can lead to double decompression. Stay consistent with pypi.
+            if filename.endswith((".tgz", ".gz")):
+                mimetype = "application/x-gzip"
+            elif filename.endswith(".bz2"):
+                mimetype = "application/octet-stream"
+            else:
+                mimetype = "auto"
+            return static_file(filename, root=x.root, mimetype=mimetype)
 
     return HTTPError(404)
 

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -211,3 +211,17 @@ def test_simple_index_list_name_with_underscore_no_egg(root, testapp):
     assert len(resp.html("a")) == 2
     hrefs = set([x["href"] for x in resp.html("a")])
     assert hrefs == set(["foo_bar/", "foo-bar/"])
+
+
+def test_mimetype(root, testapp):
+    root.join("foo_bar-1.0.tar.gz").write("")
+    root.join("foo_bar-1.0.tgz").write("")
+    root.join("foo_bar-1.0.tar.bz2").write("")
+    resp = testapp.get("/packages/foo_bar-1.0.tar.gz")
+    assert resp.content_type == 'application/x-gzip'
+    resp = testapp.get("/packages/foo_bar-1.0.tgz")
+    assert resp.content_type == 'application/x-gzip'
+    resp = testapp.get("/packages/foo_bar-1.0.tar.bz2")
+    assert resp.content_type == 'application/octet-stream'
+
+


### PR DESCRIPTION
it seems that since pip>=1.5, pip checks the response header of archives for Content-Encoding.

This is what pypiserver currently guesses when you try to download a tar.gz archive:

```
('Content-Type', 'application/x-tar')
('Content-Encoding', 'gzip')
```

What pip now does is decompressing the archive because of the Content-Encoding, without removing the .gz. Then it tries to untar it. Because of the filename it tries to decompress the tar archive again.

This is what pypi returns:

```
$ wget -S https://pypi.python.org/packages/source/p/pytz/pytz-2013.9.tar.gz 
  [...]
  Content-Type: application/x-gzip
  Accept-Ranges: bytes
  [...]
```

The patch below returns the same types as pypi does.
