### PR TITLE
add --xmlrpc-url option, --index-url was wrongly used for XMLRPC connection

### DIFF
--- a/pypiserver/core.py
+++ b/pypiserver/core.py
@@ -232,6 +232,10 @@ The following additional options can be specified with -U:
     use a different pip index url while updating. The default is to use
     https://pypi.python.org/simple.
 
+  --xmlrpc-url XMLRPC_URL
+    use a different xmlrpc url while updating. The default is to use
+    https://pypi.python.org/pypi/
+
 Visit http://pypi.python.org/pypi/pypiserver for more information.
 """)
 
@@ -249,6 +253,7 @@ def main(argv=None):
     redirect_to_fallback = True
     fallback_url = "http://pypi.python.org/simple"
     index_url = "http://pypi.python.org/simple"
+    xmlrpc_url = "https://pypi.python.org/pypi/"
     password_file = None
     overwrite = False
 
@@ -265,6 +270,7 @@ def main(argv=None):
             "root=",
             "server=",
             "fallback-url=",
+            "xmlrpc-url=",
             "disable-fallback",
             "overwrite",
             "version",
@@ -287,6 +293,8 @@ def main(argv=None):
             redirect_to_fallback = False
         elif k == "--fallback-url":
             fallback_url = v
+        elif k == "--xmlrpc-url":
+            xmlrpc_url = v
         elif k == "--server":
             if v not in server_names:
                 sys.exit("unknown server %r. choose one of %s" % (
@@ -320,7 +328,9 @@ def main(argv=None):
     if command == "update":
         packages = frozenset(itertools.chain(*[listdir(r) for r in roots]))
         from pypiserver import manage
-        manage.update(packages, update_directory, update_dry_run, stable_only=update_stable_only, index_url=index_url)
+        manage.update(packages, update_directory, update_dry_run,
+                      stable_only=update_stable_only,
+                      index_url=index_url, xmlrpc_url=xmlrpc_url)
         return
 
     a = app(

--- a/pypiserver/manage.py
+++ b/pypiserver/manage.py
@@ -85,7 +85,7 @@ def build_releases(pkg, versions):
                                replaces=pkg)
 
 
-def find_updates(pkgset, stable_only=True, index_url="https://pypi.python.org/pypi/"):
+def find_updates(pkgset, stable_only=True, xmlrpc_url="https://pypi.python.org/pypi/"):
     no_releases = set()
     filter_releases = filter_stable_releases if stable_only else (lambda x: x)
 
@@ -98,7 +98,7 @@ def find_updates(pkgset, stable_only=True, index_url="https://pypi.python.org/py
     sys.stdout.write("checking %s packages for newer version\n" % len(latest_pkgs),)
     need_update = set()
 
-    pypi = make_pypi_client(index_url)
+    pypi = make_pypi_client(xmlrpc_url)
 
     for count, pkg in enumerate(latest_pkgs):
         if count % 40 == 0:
@@ -127,8 +127,10 @@ def find_updates(pkgset, stable_only=True, index_url="https://pypi.python.org/py
     return need_update
 
 
-def update(pkgset, destdir=None, dry_run=False, stable_only=True, index_url="https://pypi.python.org/simple"):
-    need_update = find_updates(pkgset, stable_only=stable_only, index_url=index_url)
+def update(pkgset, destdir=None, dry_run=False, stable_only=True,
+           index_url="https://pypi.python.org/simple",
+           xmlrpc_url="https://pypi.python.org/pypi/"):
+    need_update = find_updates(pkgset, stable_only=stable_only, xmlrpc_url=xmlrpc_url)
     for pkg in sorted(need_update, key=lambda x: x.pkgname):
         sys.stdout.write("# update %s from %s to %s\n" % (pkg.pkgname, pkg.replaces.version, pkg.version))
 


### PR DESCRIPTION
Unfortunatly an issue was introduced with the previous merge request: The index-url was wrongly used for the xmlrcp connection. This change adds the XMLRPC url as a separate option and uses the old URL by default again.
