### PR TITLE
Improved support for upload_docs. If a docs_directory parameter is passe...

### DIFF
--- a/pypiserver/__init__.py
+++ b/pypiserver/__init__.py
@@ -6,6 +6,7 @@ def app(root=None,
         redirect_to_fallback=True,
         fallback_url=None,
         password_file=None,
+	docs_directory=None,
         overwrite=False):
     import sys, os
     from pypiserver import core
@@ -22,7 +23,7 @@ def app(root=None,
         fallback_url = "http://pypi.python.org/simple"
 
     _app.configure(root=root, redirect_to_fallback=redirect_to_fallback, fallback_url=fallback_url,
-                   password_file=password_file, overwrite=overwrite)
+                   password_file=password_file, docs_directory=docs_directory, overwrite=overwrite)
     _app.app.module = _app
 
     bottle.debug(True)

--- a/pypiserver/core.py
+++ b/pypiserver/core.py
@@ -1,7 +1,7 @@
 #! /usr/bin/env python
 """minimal PyPI like server for use with pip/easy_install"""
 
-import os, sys, getopt, re, mimetypes, warnings, itertools
+import os, os.path, sys, shutil, getopt, re, mimetypes, warnings, itertools
 
 warnings.filterwarnings("ignore", "Python 2.5 support may be dropped in future versions of Bottle")
 from pypiserver import bottle, __version__, app
@@ -160,6 +160,16 @@ def store(root, filename, data):
     dest_fh.write(data)
     dest_fh.close()
     return True
+
+
+def unzip_to(docs_directory,package_name,zipfile):
+    if docs_directory is None: return False
+    # Create a documentation folder docs_directory
+    package_docs_directory = os.path.join(docs_directory,package_name)
+    if os.path.exists(package_docs_directory):
+        shutil.rmtree(package_docs_directory)
+    os.mkdir(package_docs_directory)
+    zipfile.extractall(package_docs_directory)
 
 
 def usage():


### PR DESCRIPTION
...d in, docs will be unzipped into that directory under their package name (version skipped)

Added in support for a docs_directory parameter when starting server. Any documentation uploaded will be saved in this folder which can be served by a webserver.
