### PR TITLE
fixed redirect url

### DIFF
--- a/pypiserver/_app.py
+++ b/pypiserver/_app.py
@@ -241,7 +241,7 @@ def bad_url(prefix):
     p = request.fullpath
     if p.endswith("/"):
         p = p[:-1]
-    p = p[:p.rfind('/')]
+    p = p.rsplit('/', 1)[0]
     p += "/simple/%s/" % prefix
 
     return redirect(p)


### PR DESCRIPTION
before you would get a 303 along the lines of SERVER/sample/../simple/sample/
this was an issue because when pip would retry using this url which fails a curl with a 404.
Now we have a redirect that is SERVER/simple/sample/ which is much better and actually a valid redirect url
