### PR TITLE
Git-Ignore PyDev's (Eclipse) project files, along with *.egg

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,3 +33,4 @@ __pycache__/
 /develop-eggs/
 /eggs/
 /parts/
+/.settings/


### PR DESCRIPTION
Could be augmented with patterns from github's generic `.gitignore` for python-projects:
  https://github.com/github/gitignore/blob/master/Python.gitignore
