### PR TITLE
FIX #58: Added logging facilities

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -111,7 +111,29 @@ pypi-server -h will print a detailed usage message::
 
     -o, --overwrite
       allow overwriting existing package files
-      
+
+    -v
+      enable INFO logging;  repeate for more verbosity.
+
+    --log-file <FILE>
+      write logging info into this FILE.
+
+    --log-frmt <FILE>
+      the logging format-string.  (see `logging.LogRecord` class from standard python library)
+      [Default: %(asctime)s|%(levelname)s|%(thread)d|%(message)s] 
+
+    --log-req-frmt FORMAT
+      a format-string selecting Http-Request properties to log; set to  '%s' to see them all.
+      [Default: %(bottle.request)s] 
+
+    --log-res-frmt FORMAT
+      a format-string selecting Http-Response properties to log; set to  '%s' to see them all.
+      [Default: %(status)s]
+
+    --log-err-frmt FORMAT
+      a format-string selecting Http-Error properties to log; set to  '%s' to see them all.
+      [Default: %(body)s: %(exception)s \n%(traceback)s]
+
   pypi-server -h
   pypi-server --help
     show this help message

--- a/pypiserver/__init__.py
+++ b/pypiserver/__init__.py
@@ -6,7 +6,10 @@ def app(root=None,
         redirect_to_fallback=True,
         fallback_url=None,
         password_file=None,
-        overwrite=False):
+        overwrite=False,
+        log_req_frmt="%(bottle.request)s", 
+        log_res_frmt="%(status)s", 
+        log_err_frmt="%(body)s: %(exception)s \n%(traceback)s"):
     import sys, os
     from pypiserver import core
     sys.modules.pop("pypiserver._app", None)
@@ -22,7 +25,8 @@ def app(root=None,
         fallback_url = "http://pypi.python.org/simple"
 
     _app.configure(root=root, redirect_to_fallback=redirect_to_fallback, fallback_url=fallback_url,
-                   password_file=password_file, overwrite=overwrite)
+                   password_file=password_file, overwrite=overwrite, 
+                   log_req_frmt=log_req_frmt, log_res_frmt=log_res_frmt, log_err_frmt=log_err_frmt)
     _app.app.module = _app
 
     bottle.debug(True)

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -3,6 +3,10 @@
 from pypiserver import core  # do no remove. needed for bottle
 import pytest, bottle, webtest
 
+## Enable logging to detect any problems with it
+##
+import logging
+core.init_logging(level=logging.NOTSET)
 
 @pytest.fixture()
 def _app(app):

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -3,6 +3,11 @@
 import pytest
 from pypiserver import core
 
+## Enable logging to detect any problems with it
+##
+import logging
+core.init_logging(level=logging.NOTSET)
+
 
 files = [
     ("pytz-2012b.tar.bz2", "pytz", "2012b"),

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1,6 +1,6 @@
 #! /usr/bin/env py.test
 
-import sys, os, pytest
+import sys, os, pytest, logging
 from pypiserver import core
 
 
@@ -84,3 +84,21 @@ def test_fallback_url_default(main):
     main([])
     assert main.app.module.config.fallback_url == \
         "http://pypi.python.org/simple"
+
+@pytest.fixture
+def logfile(tmpdir):
+    return tmpdir.mkdir("logs").join('test.log')
+
+def test_logging(main, logfile):
+    main(["-v", "--log-file", logfile.strpath])
+    assert logfile.check(), logfile
+    
+def test_logging_verbosity(main):
+    main([])
+    assert logging.getLogger().level == logging.WARN 
+    main(["-v"])
+    assert logging.getLogger().level == logging.INFO 
+    main(["-v", "-v"])
+    assert logging.getLogger().level == logging.DEBUG 
+    main(["-v", "-v", "-v"])
+    assert logging.getLogger().level == logging.NOTSET


### PR DESCRIPTION
- Use standard python's logging lib.
- Log http-request/response/errors.
- Cmd-line options for logging-format and filename.
- Cmd-line options for request /response/error requests/responses/errors
  props to log.
- Add `-v` option controlling verbosity.
- Add docs about new options.
- TCs for only logging options (logging statements used throughout all tests).
