### PR TITLE
Add Cache-control header to enable pip caching

### DIFF
--- a/pypiserver/__init__.py
+++ b/pypiserver/__init__.py
@@ -9,7 +9,8 @@ def app(root=None,
         overwrite=False,
         log_req_frmt="%(bottle.request)s", 
         log_res_frmt="%(status)s", 
-        log_err_frmt="%(body)s: %(exception)s \n%(traceback)s"):
+        log_err_frmt="%(body)s: %(exception)s \n%(traceback)s",
+        cache_control=None):
     import sys, os
     from pypiserver import core
     sys.modules.pop("pypiserver._app", None)
@@ -26,7 +27,8 @@ def app(root=None,
 
     _app.configure(root=root, redirect_to_fallback=redirect_to_fallback, fallback_url=fallback_url,
                    password_file=password_file, overwrite=overwrite, 
-                   log_req_frmt=log_req_frmt, log_res_frmt=log_res_frmt, log_err_frmt=log_err_frmt)
+                   log_req_frmt=log_req_frmt, log_res_frmt=log_res_frmt, log_err_frmt=log_err_frmt,
+                   cache_control=cache_control)
     _app.app.module = _app
 
     bottle.debug(True)

--- a/pypiserver/_app.py
+++ b/pypiserver/_app.py
@@ -40,7 +40,8 @@ def configure(root=None,
               overwrite=False,
               log_req_frmt=None, 
               log_res_frmt=None,
-              log_err_frmt=None):
+              log_err_frmt=None,
+              cache_control=None):
     global packages
 
     log.info("Starting(%s)", dict(root=root,
@@ -50,7 +51,8 @@ def configure(root=None,
               overwrite=overwrite,
               log_req_frmt=log_req_frmt, 
               log_res_frmt=log_res_frmt,
-              log_err_frmt=log_err_frmt))
+              log_err_frmt=log_err_frmt,
+              cache_control=cache_control))
 
     if root is None:
         root = os.path.expanduser("~/packages")
@@ -76,6 +78,7 @@ def configure(root=None,
 
     config.redirect_to_fallback = redirect_to_fallback
     config.fallback_url = fallback_url
+    config.cache_control = cache_control
     if password_file:
         from passlib.apache import HtpasswdFile
         config.htpasswdfile = HtpasswdFile(password_file)
@@ -267,7 +270,10 @@ def server_static(filename):
     for x in entries:
         f = x.relfn.replace("\\", "/")
         if f == filename:
-            return static_file(filename, root=x.root, mimetype=mimetypes.guess_type(filename)[0])
+            response = static_file(filename, root=x.root, mimetype=mimetypes.guess_type(filename)[0])
+            if config.cache_control:
+                response.set_header("Cache-Control", "public, max-age=%s" % config.cache_control)
+            return response
 
     return HTTPError(404)
 

--- a/pypiserver/core.py
+++ b/pypiserver/core.py
@@ -235,6 +235,11 @@ pypi-server understands the following options:
     a format-string selecting Http-Error properties to log; set to  '%s' to see them all.
     [Default: %(body)s: %(exception)s \n%(traceback)s]
 
+  --cache-control AGE
+    Add "Cache-Control: max-age=AGE, public" header to package downloads.
+    Pip 6+ needs this for caching.
+
+
 pypi-server -h
 pypi-server --help
   show this help message
@@ -283,6 +288,7 @@ def main(argv=None):
     log_req_frmt = None
     log_res_frmt = None
     log_err_frmt = None
+    cache_control = None
 
     update_dry_run = True
     update_directory = None
@@ -303,6 +309,7 @@ def main(argv=None):
             "log-req-frmt=",
             "log-res-frmt=",
             "log-err-frmt=",
+            "cache-control=",
             "version",
             "help"
         ])
@@ -351,6 +358,8 @@ def main(argv=None):
             log_res_frmt = v
         elif k == "--log-err-frmt":
             log_err_frmt = v
+        elif k == "--cache-control":
+            cache_control = v
         elif k == "-v":
             verbosity += 1
         elif k in ("-h", "--help"):
@@ -379,6 +388,7 @@ def main(argv=None):
         fallback_url=fallback_url,
         overwrite=overwrite,
         log_req_frmt=log_req_frmt, log_res_frmt=log_res_frmt, log_err_frmt=log_err_frmt,
+        cache_control=cache_control,
     )
     server = server or "auto"
     sys.stdout.write("This is pypiserver %s serving %r on http://%s:%s\n\n" % (__version__, ", ".join(roots), host, port))

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -215,3 +215,20 @@ def test_simple_index_list_name_with_underscore_no_egg(root, testapp):
     assert len(resp.html("a")) == 2
     hrefs = set([x["href"] for x in resp.html("a")])
     assert hrefs == set(["foo_bar/", "foo-bar/"])
+
+
+def test_no_cache_control_set(root, _app, testapp):
+    assert not _app.config.cache_control
+    root.join("foo_bar-1.0.tar.gz").write("")
+    resp = testapp.get("/packages/foo_bar-1.0.tar.gz")
+    assert "Cache-Control" not in resp.headers
+
+
+def test_cache_control_set(root):
+    from pypiserver import app
+    AGE = 86400
+    app_with_cache = webtest.TestApp(app(root=root.strpath, cache_control=AGE))
+    root.join("foo_bar-1.0.tar.gz").write("")
+    resp = app_with_cache.get("/packages/foo_bar-1.0.tar.gz")
+    assert "Cache-Control" in resp.headers
+    assert resp.headers["Cache-Control"] == 'public, max-age=%s' % AGE


### PR DESCRIPTION
Please have a look at [pip 6 cache documentation](http://pip.readthedocs.org/en/stable/reference/pip_install.html?highlight=CacheControl#caching).

I wrote tests but I am not sure if they fit your conventions, sorry.