### PR TITLE
More deterministic sort of packages

### DIFF
--- a/pypiserver/_app.py
+++ b/pypiserver/_app.py
@@ -297,7 +297,7 @@ def simple(prefix=""):
     if not fp.endswith("/"):
         fp += "/"
 
-    files = [x.relfn for x in sorted(find_packages(packages(), prefix=prefix), key=lambda x: x.parsed_version)]
+    files = [x.relfn for x in sorted(find_packages(packages(), prefix=prefix), key=lambda x: (x.parsed_version, x.relfn))]
     if not files:
         if config.redirect_to_fallback:
             return redirect("%s/%s/" % (config.fallback_url.rstrip("/"), prefix))


### PR DESCRIPTION
We run an internal pypi server and have both sdists and wheels on it.  When refreshing they reorder because the sort only sorts on version number.  This change makes that sort more deterministic.