### PR TITLE
Add missing template loop terminators

### DIFF
--- a/pypiserver/_app.py
+++ b/pypiserver/_app.py
@@ -267,6 +267,7 @@ def simpleindex():
             <h1>Simple Index</h1>
             % for p in links:
                  <a href="{{p}}/">{{p}}</a><br>
+            % end
         </body>
     </html>
     """
@@ -299,6 +300,7 @@ def simple(prefix=""):
             <h1>Links for {{prefix}}</h1>
             % for file, href in links:
                  <a href="{{href}}">{{file}}</a><br>
+            % end
         </body>
     </html>
     """
@@ -325,6 +327,7 @@ def list_packages():
             <h1>Index of packages</h1>
             % for file, href in links:
                  <a href="{{href}}">{{file}}</a><br>
+            % end
         </body>
     </html>
     """


### PR DESCRIPTION
Fixes redundant `</body></html>` after each item in lists.