### PR TITLE
Adding optional alt_auth parameter to allow non-HTPASSWD authentication

### DIFF
--- a/pypiserver/__init__.py
+++ b/pypiserver/__init__.py
@@ -19,6 +19,7 @@ def app(root=None,
         log_err_frmt=None,
         welcome_file=None,
         cache_control=None,
+        alt_auth=None
         ):
     import sys
     import os
@@ -35,8 +36,7 @@ def app(root=None,
     _app.configure(root=root, redirect_to_fallback=redirect_to_fallback, fallback_url=fallback_url,
                    authenticated=authenticated or [], password_file=password_file, overwrite=overwrite,
                    log_req_frmt=log_req_frmt, log_res_frmt=log_res_frmt, log_err_frmt=log_err_frmt,
-                   welcome_file=welcome_file,
-                   cache_control=cache_control,
+                   welcome_file=welcome_file, cache_control=cache_control, alt_auth=alt_auth
                    )
     _app.app.module = _app
 

--- a/pypiserver/_app.py
+++ b/pypiserver/_app.py
@@ -33,6 +33,7 @@ class Configuration(object):
         self.htpasswdfile = None
         self.welcome_file = None
         self.welcome_msg = None
+        self.alt_auth = None
 
 config = Configuration()
 
@@ -56,8 +57,12 @@ class auth(object):
                 if not request.auth or request.auth[1] is None:
                     raise HTTPError(
                         401, header={"WWW-Authenticate": 'Basic realm="pypi"'})
-                if not validate_user(*request.auth):
-                    raise HTTPError(403)
+                if config.alt_auth is not None:
+                    if not config.alt_auth(*request.auth):
+                        raise HTTPError(403)
+                else:
+                    if not validate_user(*request.auth):
+                        raise HTTPError(403)
             return method(*args, **kwargs)
 
         return protector
@@ -74,6 +79,7 @@ def configure(root=None,
               log_err_frmt=None,
               welcome_file=None,
               cache_control=None,
+              alt_auth=None
               ):
     global packages
 
@@ -87,9 +93,11 @@ def configure(root=None,
                                   log_req_frmt=log_req_frmt,
                                   log_res_frmt=log_res_frmt,
                                   log_err_frmt=log_err_frmt,
-                                  cache_control=cache_control))
+                                  cache_control=cache_control,
+                                  alt_auth=alt_auth))
 
     config.authenticated = authenticated or []
+    config.alt_auth = alt_auth if type(alt_auth) is type(validate_user) else None
 
     if root is None:
         root = os.path.expanduser("~/packages")


### PR DESCRIPTION
Added optional alt_auth parameter for specification of authentication mechanism via procedural startup (i.e., __init__.app). Specifically not enabled for command-line invocation for security purposes. The alt_auth parameter propagates to _app.configure, where it is verified and added to the configuration object (which has been extended to include this field). The config.alt_auth attribute is then invoked (if assigned) in the auth decorator object as a drop-in replacement for _app.validate_user.

This is intended to give administrators the ability to hook in other authentication mechanisms when pypiserver is started procedurally. For example, the following .py file (used with a Passenger configuration) provides a basic .CSV-based method (for demo purposes only), which could just as easily be extended to LDAP or other mechanisms.

    from pypiserver import app
    import csv

    def alt_auth(user, pw):
        with open('users.csv', 'r') as f:
            dr = csv.DictReader(f)
            users = [u for u in dr]
        results = [u['username'] == user and u['password'] == pw for u in users]
        return sum(results) == 1
	
    application = app(root='packages', redirect_to_fallback=False, authenticated=['update'], alt_auth=alt_auth)
