### PR TITLE
Fixes #91

### DIFF
--- a/pypiserver/_app.py
+++ b/pypiserver/_app.py
@@ -55,7 +55,7 @@ class auth(object):
             if self.action in config.authenticated:
                 if not request.auth or request.auth[1] is None:
                     raise HTTPError(
-                        401, header={"WWW-Authenticate": 'Basic realm="pypi"'})
+                        401, headers={"WWW-Authenticate": 'Basic realm="pypi"'})
                 if not validate_user(*request.auth):
                     raise HTTPError(403)
             return method(*args, **kwargs)


### PR DESCRIPTION
Keyword argument 'header' will not be written to the corresponding header field in the 401 response. This prevents iterative HTTP requests (i.e., urllib2.HTTPBasicAuthHandler as used for distutils.command.register, as opposed to directly specifying the 'Authorization' header value in distutils.command.upload) from appropriately responding to a misplaced "www-authenticate" response header. To appropriately transcribe 'www-authenticate' when it passes from bottle.HTTPError.__init__ as an **option field to bottle.HTTPResponse__init__ as mapped to the 'headers' field, this argument was re-named.