### PR TITLE
Fix PACKAGES and SIMPLE addresses

### DIFF
--- a/pypiserver/__init__.py
+++ b/pypiserver/__init__.py
@@ -36,6 +36,7 @@ def default_config(
         host = "0.0.0.0",
         port = 8080,
         server = DEFAULT_SERVER,
+        url_prefix=None,
         redirect_to_fallback = True,
         fallback_url = None,
         authenticated = ['update'],

--- a/pypiserver/__main__.py
+++ b/pypiserver/__main__.py
@@ -78,6 +78,10 @@ def usage():
       default is to use "auto" which chooses one of paste, cherrypy,
       twisted or wsgiref.
 
+    -f, --url-prefix PREFIX
+      in case of using nginx with custom path you have to use PREFIX to
+      override links
+
     -r, --root PACKAGES_DIRECTORY
       [deprecated] serve packages from PACKAGES_DIRECTORY
 
@@ -162,13 +166,14 @@ def main(argv=None):
     update_stable_only = True,
 
     try:
-        opts, roots = getopt.getopt(argv[1:], "i:p:a:r:d:P:Uuvxoh", [
+        opts, roots = getopt.getopt(argv[1:], "i:p:a:r:d:P:f:Uuvxoh", [
             "interface=",
             "passwords=",
             "authenticate=",
             "port=",
             "root=",
             "server=",
+            "url-prefix=",
             "fallback-url=",
             "disable-fallback",
             "overwrite",
@@ -216,6 +221,8 @@ def main(argv=None):
             c.fallback_url = v
         elif k == "--server":
             c.server = v
+        elif k in ("-f", "--url-prefix"):
+            c.url_prefix = v
         elif k == "--welcome":
             c.welcome_file = v
         elif k == "--version":

--- a/pypiserver/_app.py
+++ b/pypiserver/_app.py
@@ -72,6 +72,12 @@ def favicon():
 
 @app.route('/')
 def root():
+    if config.url_prefix:
+        prefix = url = config.url_prefix
+    else:
+        prefix = request.fullpath
+        url = request.url
+
     try:
         numpkgs = len(list(packages()))
     except:
@@ -80,11 +86,11 @@ def root():
     # Ensure template() does not consider `msg` as filename!
     msg = config.welcome_msg + '\n'
     return template(msg,
-                    URL=request.url,
+                    URL=os.path.join(url, "simple/"),
                     VERSION=__version__,
                     NUMPKGS=numpkgs,
-                    PACKAGES=urljoin(request.url, "packages/"),
-                    SIMPLE=urljoin(request.url, "simple/")
+                    PACKAGES=os.path.join(prefix, "packages/"),
+                    SIMPLE=os.path.join(prefix, "simple/")
                     )
 
 

--- a/pypiserver/_app.py
+++ b/pypiserver/_app.py
@@ -72,8 +72,6 @@ def favicon():
 
 @app.route('/')
 def root():
-    fp = request.fullpath
-
     try:
         numpkgs = len(list(packages()))
     except:
@@ -85,8 +83,8 @@ def root():
                     URL=request.url,
                     VERSION=__version__,
                     NUMPKGS=numpkgs,
-                    PACKAGES=urljoin(fp, "packages/"),
-                    SIMPLE=urljoin(fp, "simple/")
+                    PACKAGES=urljoin(request.url, "packages/"),
+                    SIMPLE=urljoin(request.url, "simple/")
                     )
 
 

--- a/pypiserver/welcome.html
+++ b/pypiserver/welcome.html
@@ -4,12 +4,12 @@
 
 <p> To use this server with pip, run the the following command:
 <blockquote><pre>
-pip install --extra-index-url {{URL}}simple/ PACKAGE [PACKAGE2...]
+pip install --extra-index-url {{URL}} PACKAGE [PACKAGE2...]
 </pre></blockquote></p>
 
 <p> To use this server with easy_install, run the the following command:
 <blockquote><pre>
-easy_install -i {{URL}}simple/ PACKAGE
+easy_install -i {{URL}} PACKAGE
 </pre></blockquote></p>
 
 <p>The complete list of all packages can be found <a href="{{PACKAGES}}">here</a>


### PR DESCRIPTION
I use Nginx as a reverse proxy. For example, if the welcome page of my repository is available at https://myserver/pypi, then the `here` and `simple` links on the page will be pointing to `https://myserver/packages/` and `https://myserver/simple/` respectively. It's wrong.  I propose a small patch which fixes it.