### PR TITLE
Serve tens of thousands of packages efficiently

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -368,6 +368,24 @@ Specifying an additional `-u` option will also allow alpha, beta and
 release candidates to be downloaded. Without this option these
 releases won't be considered.
 
+Serving thousands of packages
+-----------------------------
+
+By default, pypiserver scans the entire packages directory each time an
+incoming HTTP request occurs. This isn't a problem for a small number of
+packages, but causes noticeable slowdowns when serving thousands or tens
+of thousands of packages.
+
+If you run into this problem, significant speedups can be gained by enabling
+pypiserver's directory caching functionality. The only requirement is to
+install the ``watchdog`` package, or it can be installed by installing
+``pypiserver`` using the ``cache`` extras option::
+
+  pip install pypi-server[cache]
+
+If you are using a static webserver such as Apache or Nginx as a proxy for
+pypiserver, additional speedup can be gained by directly serving the
+packages directory.
 
 Using a different WSGI server
 -----------------------------

--- a/pypiserver/_app.py
+++ b/pypiserver/_app.py
@@ -192,7 +192,7 @@ def simple(prefix=""):
         return HTTPError(404)
 
     links = [(os.path.basename(f.relfn),
-              urljoin(fp, "../../packages/%s#%s" % (f.relfn_unix(),
+              urljoin(fp, "../../packages/%s#%s" % (f.relfn_unix,
 
                                          f.hash(config.hash_algo))))
              for f in files]
@@ -224,7 +224,7 @@ def list_packages():
                       key=lambda x: (os.path.dirname(x.relfn),
                                      x.pkgname,
                                      x.parsed_version))
-    links = [(f.relfn_unix(), '%s#%s' % (urljoin(fp, f.relfn),
+    links = [(f.relfn_unix, '%s#%s' % (urljoin(fp, f.relfn),
                                          f.hash(config.hash_algo)))
              for f in files]
     tmpl = """\
@@ -248,7 +248,7 @@ def list_packages():
 def server_static(filename):
     entries = core.find_packages(packages())
     for x in entries:
-        f = x.relfn_unix()
+        f = x.relfn_unix
         if f == filename:
             response = static_file(
                 filename, root=x.root, mimetype=mimetypes.guess_type(filename)[0])

--- a/pypiserver/cache.py
+++ b/pypiserver/cache.py
@@ -1,0 +1,49 @@
+
+# Dumb cache implementation -- requires watchdog to be installed
+
+# Basically -- cache the results of listdir in memory until something
+# gets modified, then invalidate the whole thing
+
+
+from watchdog.observers import Observer
+import threading
+
+class ListdirCache(object):
+
+    def __init__(self):
+        self.cache = {}
+        self.observer = Observer()
+        self.observer.start()
+
+        self.watched = set()
+        self.lock = threading.Lock()
+
+    def get(self, root, fn):
+        with self.lock:
+            try:
+                return self.cache[root]
+            except KeyError:
+                # check to see if we're watching
+                if root not in self.watched:
+                    self._watch(root)
+
+                v = list(fn(root))
+                self.cache[root] = v
+                return v
+
+    def _watch(self, root):
+        self.watched.add(root)
+        self.observer.schedule(_EventHandler(self, root), root, recursive=True)
+
+class _EventHandler(object):
+
+    def __init__(self, lcache, root):
+        self.lcache = lcache
+        self.root = root
+
+    def dispatch(self, event):
+        '''Called by watchdog observer'''
+        with self.lcache.lock:
+            self.lcache.cache.pop(self.root, None)
+
+listdir_cache = ListdirCache()

--- a/pypiserver/core.py
+++ b/pypiserver/core.py
@@ -133,6 +133,10 @@ wheel_file_re = re.compile(
     \.whl|\.dist-info)$""",
     re.VERBOSE)
 
+_pkgname_re = re.compile(r'-(?i)v?\d+[\.a-z]')
+_pkgname_parts_re = re.compile(r'[\.\-](?=(?i)cp\d|py\d|macosx|linux|sunos|'
+                                'solaris|irix|aix|cygwin|win)')
+
 
 def _guess_pkgname_and_version_wheel(basename):
     m = wheel_file_re.match(basename)
@@ -161,10 +165,9 @@ def guess_pkgname_and_version(path):
     elif '.' not in path:
         pkgname, version = path.rsplit('-', 1)
     else:
-        pkgname = re.split(r'-(?i)v?\d+[\.a-z]', path)[0]
+        pkgname = _pkgname_re.split(path)[0]
         ver_spec = path[len(pkgname) + 1:]
-        parts = re.split(r'[\.\-](?=(?i)cp\d|py\d|macosx|linux|sunos|'
-                         'solaris|irix|aix|cygwin|win)', ver_spec)
+        parts = _pkgname_parts_re.split(ver_spec)
         version = parts[0]
     return pkgname, version
 

--- a/pypiserver/manage.py
+++ b/pypiserver/manage.py
@@ -84,9 +84,8 @@ def build_releases(pkg, versions):
     for x in versions:
         parsed_version = core.parse_version(x)
         if parsed_version > pkg.parsed_version:
-            yield core.PkgFile(version=x,
-                               parsed_version=parsed_version,
-                               pkgname=pkg.pkgname,
+            yield core.PkgFile(pkgname=pkg.pkgname,
+                               version=x,
                                replaces=pkg)
 
 

--- a/setup.py
+++ b/setup.py
@@ -36,7 +36,8 @@ setup(name="pypiserver",
           'wheel',
       ],
       extras_require={
-          'passlib': ['passlib']
+          'passlib': ['passlib'],
+          'cache': ['watchdog']
       },
       tests_require=tests_require,
       url="https://github.com/pypiserver/pypiserver",

--- a/tests/test_manage.py
+++ b/tests/test_manage.py
@@ -13,8 +13,9 @@ def touch_files(root, files):
 
 def pkgfile_from_path(fn):
     pkgname, version = guess_pkgname_and_version(fn)
-    return PkgFile(root=py.path.local(fn).parts()[1].strpath,
-                   fn=fn, pkgname=pkgname, version=version, parsed_version=parse_version(version))
+    return PkgFile(pkgname=pkgname, version=version,
+                   root=py.path.local(fn).parts()[1].strpath,
+                   fn=fn)
 
 
 @pytest.mark.parametrize(
@@ -40,7 +41,8 @@ def test_build_releases():
                     version='0.3.0')
 
     res, = list(build_releases(p, ["0.3.0"]))
-    assert res.__dict__ == expected
+    for k, v in expected.items():
+        assert getattr(res, k) == v
 
 
 def test_filter_stable_releases():


### PR DESCRIPTION
pypiserver has worked great for us over the last 2 years, but over time we've accumulated 25000 individual package files (mostly artifacts from automatic builds) and pypiserver has really slowed down for us.

This PR adds some significant optimizations for this particular use case -- in particular, it holds the list of packages in memory so we don't have to scan all 25000 packages each time pip queries the server (which is a few times per package). It uses the `watchdog` package to invalidate the cache, and will not activate the cache if it is not installed.

Another significant speedup we found was using an nginx proxy, and adding the following to make nginx serve the packages directly by pointing the `/packages/` location to its parent directory:
```
  location /packages/ {
    root /path/to/packages/parentdir;
  }
```