### PR TITLE
Allow automated upload of GPG-signatures

### DIFF
--- a/pypiserver/_app.py
+++ b/pypiserver/_app.py
@@ -145,10 +145,10 @@ def update():
         raise HTTPError(400, "Missing 'content' file-field!")
 
     if (not is_valid_pkg_filename(content.raw_filename) or
-                core.guess_pkgname_and_version(content.raw_filename) is None):
+            core.guess_pkgname_and_version(content.raw_filename) is None):
         raise HTTPError(400, "Bad filename: %s" % content.raw_filename)
 
-    if not config.overwrite and core.exists(packages.root, content.filename):
+    if not config.overwrite and core.exists(packages.root, content.raw_filename):
         log.warn("Cannot upload package(%s) since it already exists! \n" +
                  "  You may use `--overwrite` option when starting server to disable this check. ",
                  content.raw_filename)
@@ -156,30 +156,29 @@ def update():
         raise HTTPError(409, msg)
 
     try:
-        gpg_signature = request.files['gpg_signature']
+        gpg_sig = request.files['gpg_signature']
     except KeyError:
-        gpg_signature = None
-
-    if (gpg_signature is not None and
-            (not is_valid_pkg_filename(gpg_signature.raw_filename)
-             or core.guess_pkgname_and_version(content.raw_filename) is None)):
-        raise HTTPError(400, "Bad gpg signature name: %s" %
-                        gpg_signature.raw_filename)
-
-    if not config.overwrite and core.exists(packages.root,
-                                            gpg_signature.filename):
-        log.warn("Cannot upload package(%s) because its signature already "
-                 "exists! \n  You may use the `--overwrite` option when"
-                 "starting the server to disable this check.")
-        msg = ("Signature file already exists! Start server with "
-               "`--overwrite` option?")
-        raise HTTPError(409, msg)
-
-    if gpg_signature is None:
-        core.store(packages.root, content.filename, content.save)
+        gpg_sig = None
     else:
-        core.store(packages.root, content.filename, content.save,
-                   gpg_signature.filename, gpg_signature.save)
+        if (not is_valid_pkg_filename(gpg_sig.raw_filename) or
+            core.guess_pkgname_and_version(gpg_sig.raw_filename) is None):
+            raise HTTPError(400, "Bad gpg signature name: %s" %
+                            gpg_sig.raw_filename)
+
+        if not config.overwrite and core.exists(packages.root,
+                                                gpg_sig.raw_filename):
+            log.warn("Cannot upload package(%s) because its signature already "
+                     "exists! \n  You may use the `--overwrite` option when"
+                     "starting the server to disable this check.")
+            msg = ("Signature file already exists! Start server with "
+                   "`--overwrite` option?")
+            raise HTTPError(409, msg)
+
+    if gpg_sig is None:
+        core.store(packages.root, content.raw_filename, content.save)
+    else:
+        core.store(packages.root, content.raw_filename, content.save,
+                   gpg_sig.raw_filename, gpg_sig.save)
 
     return ""
 

--- a/pypiserver/_app.py
+++ b/pypiserver/_app.py
@@ -166,7 +166,6 @@ def update():
         raise HTTPError(400, "Bad gpg signature name: %s" %
                         gpg_signature.raw_filename)
 
-
     if not config.overwrite and core.exists(packages.root,
                                             gpg_signature.filename):
         log.warn("Cannot upload package(%s) because its signature already "

--- a/pypiserver/_app.py
+++ b/pypiserver/_app.py
@@ -151,7 +151,10 @@ def update():
     try:
         gpg_signature = request.files['gpg_signature']
     except KeyError:
-        gpg_signature = None
+        gpg_filename = gpg_save = None
+    else:
+        gpg_filename = gpg_signature.filename
+        gpg_save = gpg_signature.save
 
     if "/" in content.filename:
         raise HTTPError(400, output="bad filename")
@@ -164,7 +167,7 @@ def update():
         raise HTTPError(409, msg)
 
     core.store(packages.root, content.filename, content.save,
-               gpg_signature.filename, gpg_signature.save)
+               gpg_filename, gpg_save)
     return ""
 
 

--- a/pypiserver/core.py
+++ b/pypiserver/core.py
@@ -91,6 +91,7 @@ def auth_by_htpasswd_file(htPsswdFile, username, password):
 
 mimetypes.add_type("application/octet-stream", ".egg")
 mimetypes.add_type("application/octet-stream", ".whl")
+mimetypes.add_type("text/plain", ".asc")
 
 
 #### Next 2 functions adapted from :mod:`distribute.pkg_resources`.

--- a/pypiserver/core.py
+++ b/pypiserver/core.py
@@ -129,6 +129,7 @@ _archive_suffix_rx = re.compile(
     r"(\.zip|\.tar\.gz|\.tgz|\.tar\.bz2|-py[23]\.\d-.*|"
     "\.win-amd64-py[23]\.\d\..*|\.win32-py[23]\.\d\..*|\.egg)$",
     re.I)
+
 wheel_file_re = re.compile(
     r"""^(?P<namever>(?P<name>.+?)-(?P<ver>\d.*?))
     ((-(?P<build>\d.*?))?-(?P<pyver>.+?)-(?P<abi>.+?)-(?P<plat>.+?)
@@ -277,11 +278,15 @@ def exists(root, filename):
     return os.path.exists(dest_fn)
 
 
-def store(root, filename, save_method):
+def store(root, filename, save_method,
+          gpg_filename=None, gpg_save_method=None):
     assert "/" not in filename
     dest_fn = os.path.join(root, filename)
     save_method(dest_fn, overwrite=True) # Overwite check elsewhere.
-
+    if gpg_filename is not None:
+        assert gpg_save_method is not None
+        gpg_dest_fn = os.path.join(root, gpg_filename)
+        save_method(gpg_dest_fn, overwrite=True)
     log.info("Stored package: %s", filename)
     return True
 

--- a/pypiserver/core.py
+++ b/pypiserver/core.py
@@ -156,6 +156,8 @@ def _guess_pkgname_and_version_wheel(basename):
 
 def guess_pkgname_and_version(path):
     path = os.path.basename(path)
+    if path.endswith(".asc"):
+        path = path.rstrip(".asc")
     if path.endswith(".whl"):
         return _guess_pkgname_and_version_wheel(path)
     if not _archive_suffix_rx.search(path):

--- a/pypiserver/core.py
+++ b/pypiserver/core.py
@@ -286,7 +286,6 @@ def store(root, filename, save_method,
     dest_fn = os.path.join(root, filename)
     save_method(dest_fn, overwrite=True) # Overwite check elsewhere.
     if gpg_filename is not None:
-        assert gpg_save_method is not None
         gpg_dest_fn = os.path.join(root, gpg_filename)
         save_method(gpg_dest_fn, overwrite=True)
     log.info("Stored package: %s", filename)

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -55,10 +55,6 @@ files = [
     ("foo/pkg.zip", 'pkg', ''),
     ("foo/pkg-1b.zip", 'pkg', '1b'),
     ("package-name-0.0.1.alpha.1.win-amd64-py3.2.exe", "package-name", "0.0.1.alpha.1"),
-    ("some_package-0.1.0-py2.py3-none-any.whl", "some_package", "0.1.0"),
-    ("some_package-0.1.0-py2.py3-none-any.whl.asc", "some_package", "0.1.0"),
-    ("some_package-0.1.0.tar.gz.asc", "some_package", "0.1.0"),
-    ("some_package-0.1.0.tar.gz", "some_package", "0.1.0")
 ]
 
 def _capitalize_ext(fpath):
@@ -72,6 +68,12 @@ def test_guess_pkgname_and_version(filename, pkgname, version):
     exp = (pkgname, version)
     assert core.guess_pkgname_and_version(filename) == exp
     assert core.guess_pkgname_and_version(_capitalize_ext(filename)) == exp
+
+@pytest.mark.parametrize(("filename", "pkgname", "version"), files)
+def test_guess_pkgname_and_version_asc(filename, pkgname, version):
+    exp = (pkgname, version)
+    filename = '%s.asc' % filename
+    assert core.guess_pkgname_and_version(filename) == exp
 
 
 def test_listdir_bad_name(tmpdir):

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -54,7 +54,11 @@ files = [
     ("pkg.zip", 'pkg', ''),
     ("foo/pkg.zip", 'pkg', ''),
     ("foo/pkg-1b.zip", 'pkg', '1b'),
-    ("some_package-0.1.0-py2.py3-none-any.whl.asc", "some_package", "0.1.0")
+    ("package-name-0.0.1.alpha.1.win-amd64-py3.2.exe", "package-name", "0.0.1.alpha.1"),
+    ("some_package-0.1.0-py2.py3-none-any.whl", "some_package", "0.1.0"),
+    ("some_package-0.1.0-py2.py3-none-any.whl.asc", "some_package", "0.1.0"),
+    ("some_package-0.1.0.tar.gz.asc", "some_package", "0.1.0"),
+    ("some_package-0.1.0.tar.gz", "some_package", "0.1.0")
 ]
 
 def _capitalize_ext(fpath):

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -54,6 +54,7 @@ files = [
     ("pkg.zip", 'pkg', ''),
     ("foo/pkg.zip", 'pkg', ''),
     ("foo/pkg-1b.zip", 'pkg', '1b'),
+    ("some_package-0.1.0-py2.py3-none-any.whl.asc", "some_package", "0.1.0")
 ]
 
 def _capitalize_ext(fpath):


### PR DESCRIPTION
I am using pypiserver to host private enterprise packages, and we wanted to be able to verify the packages with our gpg key. With the official PyPi server, uploading a package with the `--sign` option or specifing `-s` in twine uploads a `.asc` file along with the package source/distribution. We wanted to have the same functionality with pypiserver. This PR accomplishes that via the following changes:

* The upload post (`request.files`) is now checked for a `gpg_signature` key. 
* If the key exists, the signature filename and save method are passed into the `core.store` method, which has been updated with new parameters for said filename and save method.
* If the key does not exist, the `core.store` method is run as before
* Added a check for `.asc` files in the `core.guess_pkgname_and_version` function. If a file ends with `.asc`, the `.asc` is removed from the end before the function continues, to allow proper parsing of the package name and version for the `.asc` files.
* Added tests for `core.guess_pkgname_and_version` parsing `.asc` files

Works with both `setup.py` and twine uploading. Signature files appear associated with the appropriate package in the simple index, as well as in the all files index.

I wasn't sure how to write proper tests for the upload of packages, because most of the `test_server` tests fail on my system. 