### PR TITLE
Added python3.5 support to setup.py and tests for #108

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,7 @@ env:
   - TOX_ENV=py32
   - TOX_ENV=py33
   - TOX_ENV=py34
+  - TOX_ENV=py35
   - TOX_ENV=pypy
 
 script:

--- a/README.rst
+++ b/README.rst
@@ -27,7 +27,7 @@ The packages are stored in regular directories.
 
 Quickstart: Installation and Usage
 ==================================
-*pypiserver* will work with python 2.5 --> 2.7 and 3.2 --> 3.4.
+*pypiserver* will work with python 2.5 --> 2.7 and 3.2 --> 3.5.
 Python 3.0 and 3.1 may also work, but pypiserver is not being tested
 with these versions.
 

--- a/setup.py
+++ b/setup.py
@@ -13,6 +13,12 @@ tests_require = ['pytest>=2.3', 'tox', 'twine', 'pip>=7', 'passlib', 'webtest']
 if sys.version_info <= (3, 2):
     tests_require.append('mock')
 
+setup_requires = ['setuptools', 'setuptools-git >= 0.3']
+if sys.version_info >= (3,5):
+    setup_requires.append('wheel >= 0.25.0')  # earlier wheels fail in 3.5
+else:
+    setup_requires.append('wheel')
+
 
 def get_version():
     d = {}
@@ -29,12 +35,7 @@ setup(name="pypiserver",
       version=get_version(),
       packages=["pypiserver"],
       package_data={'pypiserver': ['welcome.html']},
-      setup_requires=[
-          'setuptools',
-          # Gather package-data from all files in git.
-          'setuptools-git >= 0.3',
-          'wheel',
-      ],
+      setup_requires=setup_requires,
       extras_require={
           'passlib': ['passlib'],
           'cache': ['watchdog']

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py25,py26,py27,py32,py33,py34
+envlist = py25,py26,py27,py32,py33,py34,py35
 
 [testenv]
 deps=-r{toxinidir}/requirements/dev.pip


### PR DESCRIPTION
The only slightly weird thing is the wheel requirement for setup. Versions of wheel prior to 0.25.0 would fail with certain build configurations in python 3.5 (see the discussion [here](https://bitbucket.org/pypa/wheel/issues/146/wheel-building-fails-on-cpython-350b3)).