### PR TITLE
Bug fix for overwriting existing files without the overwrite flag bei…

### DIFF
--- a/pypiserver/_app.py
+++ b/pypiserver/_app.py
@@ -153,7 +153,7 @@ def file_upload():
             log.warn("Cannot upload %r since it already exists! \n"
                      "  You may start server with `--overwrite` option. ",
                      uf.raw_filename)
-            HTTPError(409, "Package %r already exists!\n"
+            raise HTTPError(409, "Package %r already exists!\n"
                       "  You may start server with `--overwrite` option.",
                       uf.raw_filename)
 


### PR DESCRIPTION
Bug fix for overwriting existing files without the overwrite flag being set to true.

Looks like a simple oversite where a raise should have been done.

The current log output looks like 

<LocalRequest: POST http://10.1.10.155:8092/>
Cannot upload 'testpackage-2.0.2.tar.gz' since it already exists! 
  You may start server with `--overwrite` option. 
Stored 'testpackage-2.0.2.tar.gz'.
200 OK