### PR TITLE
Topic/allow search with pip

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -48,6 +48,8 @@ From the client computer, type this::
 
   ## Download and Install hosted packages.
   pip install  --extra-index-url http://localhost:8080/simple/ ...
+  ## Search hosted packages
+  pip search --index http://localhost:8080/simple/ ...
 
 See also `Client-side configurations`_ for avoiding tedious typing.
 

--- a/pypiserver/_app.py
+++ b/pypiserver/_app.py
@@ -223,6 +223,7 @@ def handle_rpc():
 
 
 @app.route("/simple/")
+@auth("list")
 def simpleindex():
     links = sorted(core.get_prefixes(packages()))
     tmpl = """\

--- a/pypiserver/_app.py
+++ b/pypiserver/_app.py
@@ -5,6 +5,7 @@ import os
 import re
 import sys
 import zipfile
+import xml.dom.minidom
 
 from . import __version__
 from . import core
@@ -20,6 +21,48 @@ try:  # PY3
     from urllib.parse import urljoin
 except ImportError:  # PY2
     from urlparse import urljoin
+
+XMLRPC_RESPONSE_SKELETON = '''
+
+
+
+
+%(objects)s
+
+
+
+'''
+
+
+def from_obj_to_xmlrpc(obj_):
+    res = ""
+    if isinstance(obj_, int):
+        res += "%s" % obj_
+        return res
+    elif isinstance(obj_, str):
+        res += "%s" % obj_
+        return res
+    elif isinstance(obj_,dict):
+        res += ""
+        for k, v in obj_.iteritems():
+            member = {}
+            member["name"] = k
+            member["value"] = from_obj_to_xmlrpc(v)
+            res_1 = ""
+            res_1 += "%(name)s"
+            res_1 += "%(value)s"
+            res_1 += ""
+            res += res_1 % member
+        res += ""
+        return res
+    elif isinstance(obj_, list):
+        res += ""
+        for i in obj_:
+            res += "%s" % from_obj_to_xmlrpc(i)
+        res += ""
+        return res
+    else:
+        raise Exception("No valid object")
 
 
 log = logging.getLogger(__name__)
@@ -193,8 +236,32 @@ def simpleindex_redirect():
     return redirect(request.fullpath + "/")
 
 
-@app.route("/simple/")
+@app.post('/search')
+@app.post('/search/')
 @auth("list")
+def search():
+    value = ""
+    try:
+        parser = xml.dom.minidom.parse(request.body)
+        member = parser.getElementsByTagName("member")[0]
+        value = parser.getElementsByTagName(
+            "string")[0].childNodes[0].wholeText.strip()
+    except Exception as e:
+        value = ""
+
+    response = []
+    ordering = 0
+    for p in packages():
+        if p.pkgname.count(value) > 0:
+            d = {'_pypi_ordering': ordering, 'version': p.version,
+                 'name': p.pkgname, 'summary': p.fn}
+            response.append(d)
+        ordering += 1
+    res = XMLRPC_RESPONSE_SKELETON \
+        % {"objects":from_obj_to_xmlrpc(response)}
+    return res
+
+@app.route("/simple/")
 def simpleindex():
     links = sorted(core.get_prefixes(packages()))
     tmpl = """\

--- a/pypiserver/_app.py
+++ b/pypiserver/_app.py
@@ -213,8 +213,9 @@ def handle_rpc():
         ordering = 0
         for p in packages():
             if p.pkgname.count(value) > 0:
+                # We do not presently have any description/summary, returning version instead
                 d = {'_pypi_ordering': ordering, 'version': p.version,
-                     'name': p.pkgname, 'summary': p.fn}
+                     'name': p.pkgname, 'summary': p.version}
                 response.append(d)
             ordering += 1
         call_string = xmlrpclib.dumps( (response,), 'search', methodresponse=True)

--- a/pypiserver/_app.py
+++ b/pypiserver/_app.py
@@ -3,7 +3,6 @@ import logging
 import mimetypes
 import os
 import re
-import sys
 import zipfile
 import xml.dom.minidom
 
@@ -201,24 +200,26 @@ def simpleindex_redirect():
 @app.post('/RPC2')
 @auth("list")
 def handle_rpc():
-    value = ""
+    """Handle pip-style RPC2 search requests"""
     parser = xml.dom.minidom.parse(request.body)
-    methodname = parser.getElementsByTagName("methodName")[0].childNodes[0].wholeText.strip()
+    methodname = parser.getElementsByTagName(
+        "methodName")[0].childNodes[0].wholeText.strip()
     log.info("Processing RPC2 request for '%s'", methodname)
     if methodname == 'search':
         value = parser.getElementsByTagName(
             "string")[0].childNodes[0].wholeText.strip()
-
         response = []
         ordering = 0
         for p in packages():
             if p.pkgname.count(value) > 0:
-                # We do not presently have any description/summary, returning version instead
+                # We do not presently have any description/summary, returning
+                # version instead
                 d = {'_pypi_ordering': ordering, 'version': p.version,
                      'name': p.pkgname, 'summary': p.version}
                 response.append(d)
             ordering += 1
-        call_string = xmlrpclib.dumps( (response,), 'search', methodresponse=True)
+        call_string = xmlrpclib.dumps((response,), 'search',
+                                      methodresponse=True)
         return call_string
 
 

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -1,21 +1,26 @@
 #! /usr/bin/env py.test
 
-import contextlib
-import glob
+# Builtin imports
 import logging
-import os
-from pypiserver import __main__, bottle
-import subprocess
-
-import pytest
-import webtest
-
-import test_core
 
 try:
     from html.parser import HTMLParser
 except ImportError:
     from HTMLParser import HTMLParser
+
+try:
+    import xmlrpc.client as xmlrpclib
+except ImportError:
+    import xmlrpclib  # legacy Python
+
+# Third party imports
+import pytest
+import webtest
+
+
+# Local Imports
+from pypiserver import __main__, bottle
+import tests.test_core as test_core
 
 
 # Enable logging to detect any problems with it
@@ -37,11 +42,13 @@ def app(tmpdir):
 
 @pytest.fixture
 def testapp(app):
+    """Return a webtest TestApp initiated with pypiserver app"""
     return webtest.TestApp(app)
 
 
 @pytest.fixture
 def root(tmpdir):
+    """Return a pytest temporary directory"""
     return tmpdir
 
 
@@ -57,11 +64,24 @@ def testpriv(priv):
     return webtest.TestApp(priv)
 
 
-@pytest.fixture(params=["  ",  # Mustcontain test below fails when string is empty.
-                        "Hey there!",
-                        "<html><body>Hey there!</body></html>",
-                        ])
+@pytest.fixture
+def search_xml():
+    """Return an xml dom suitable for passing to search"""
+    xml = '<xml><methodName>search</methodName><string>test</string></xml>'
+    return xml
+
+
+@pytest.fixture(params=[
+    "  ",  # Mustcontain test below fails when string is empty.
+    "Hey there!",
+    "<html><body>Hey there!</body></html>",
+])
 def welcome_file_no_vars(request, root):
+    """Welcome file fixture
+
+    :param request: pytest builtin fixture
+    :param root: root temporary directory
+    """
     wfile = root.join("testwelcome.html")
     wfile.write(request.param)
 
@@ -84,6 +104,11 @@ def welcome_file_all_vars(request, root):
 
 
 def test_root_count(root, testapp):
+    """Test that the welcome page count updates with added packages
+
+    :param root: root temporary directory fixture
+    :param testapp: webtest TestApp
+    """
     resp = testapp.get("/")
     resp.mustcontain("PyPI compatible package index serving 0 packages")
     root.join("Twisted-11.0.0.tar.bz2").write("")
@@ -313,15 +338,18 @@ def test_cache_control_set(root):
     assert "Cache-Control" in resp.headers
     assert resp.headers["Cache-Control"] == 'public, max-age=%s' % AGE
 
+
 def test_upload_noAction(root, testapp):
     resp = testapp.post("/", expect_errors=1)
     assert resp.status == '400 Bad Request'
     assert "Missing ':action' field!" in hp.unescape(resp.text)
 
+
 def test_upload_badAction(root, testapp):
     resp = testapp.post("/", params={':action': 'BAD'}, expect_errors=1)
     assert resp.status == '400 Bad Request'
     assert "Unsupported ':action' field: BAD" in hp.unescape(resp.text)
+
 
 @pytest.mark.parametrize(("package"), [f[0] 
         for f in test_core.files 
@@ -333,6 +361,7 @@ def test_upload(package, root, testapp):
     uploaded_pkgs = [f.basename for f in root.listdir()]
     assert len(uploaded_pkgs) == 1
     assert uploaded_pkgs[0].lower() == package.lower()
+
 
 @pytest.mark.parametrize(("package"), [f[0] 
         for f in test_core.files 
@@ -347,6 +376,7 @@ def test_upload_with_signature(package, root, testapp):
     assert len(uploaded_pkgs) == 2
     assert uploaded_pkgs[0].lower() == package.lower()
     assert uploaded_pkgs[1].lower() == '%s.asc' % package.lower()
+
 
 @pytest.mark.parametrize(("package"), [
         f[0] for f in test_core.files
@@ -377,6 +407,7 @@ def test_remove_pkg_missingNaveVersion(name, version, root, testapp):
     assert resp.status == '400 Bad Request'
     assert msg %(name, version) in hp.unescape(resp.text)
 
+
 def test_remove_pkg_notFound(root, testapp):
     resp = testapp.post("/", expect_errors=1,
             params={
@@ -386,6 +417,62 @@ def test_remove_pkg_notFound(root, testapp):
     })
     assert resp.status == '404 Not Found'
     assert "foo (123) not found" in hp.unescape(resp.text)
+
+
+@pytest.mark.parametrize('pkgs,matches', [
+    ([], []),
+    (['test-1.0.tar.gz'], [('test', '1.0')]),
+    (['test-1.0.tar.gz', 'test-test-2.0.1.tar.gz'],
+     [('test', '1.0'), ('test-test', '2.0.1')]),
+    (['test-1.0.tar.gz', 'other-2.0.tar.gz'], [('test', '1.0')]),
+    (['test-2.0-py2.py3-none-any.whl'], [('test', '2.0')]),
+    (['other-2.0.tar.gz'], [])
+])
+def test_search(root, testapp, search_xml, pkgs, matches):
+    """Test the search functionality at the RPC2 endpoint
+
+    Calls the handle_rpc function by posting to the WebTest server with
+    the string returned by the ``search_xml`` fixture as the request
+    body. The result is parsed for convenience by the xmlrpc.client
+    (xmlrpclib in Python 2.x). The parsed result is a 2-tuple. The
+    second item is the method called, in this case always "search". The
+    first item is a 1-tuple which contains a list of match information
+    as dicts, e.g:
+
+    ``(([{'version': '2.0', '_pypi_ordering': 0,
+    'name': 'test', 'summary': '2.0'}],), 'search')``
+
+    The pkgs parameter is a list of items to write to the packages
+    directory, which should then be available for the subsequent
+    search. The matches parameter is a list of 2-tuples of the form
+    (``name``, ``version``), where ``name`` and ``version`` are the
+    expected name and version matches for a search for the "test"
+    package as specified by the search_xml fixture.
+
+    :param root: root temporry directory fixture; used as packages dir
+        for testapp
+    :param testapp: webtest TestApp
+    :param str search_xml: XML string roughly equivalent to a pip search
+        for "test"
+    :param pkgs: package file names to be written into packages
+        directory
+    :param matches: a list of 2-tuples containing expected (name,
+        version) matches for the "test" query
+    """
+    for pkg in pkgs:
+        root.join(pkg).write('')
+    resp = testapp.post('/RPC2', search_xml)
+    parsed = xmlrpclib.loads(resp.text)
+    assert len(parsed) == 2 and parsed[1] == 'search'
+    if not matches:
+        assert len(parsed[0]) == 1 and not parsed[0][0]
+    else:
+        assert len(parsed[0][0]) == len(matches) and parsed[0][0]
+        for returned in parsed[0][0]:
+            print(returned)
+            assert returned['name'] in [match[0] for match in matches]
+            assert returned['version'] in [match[1] for match in matches]
+
 
 @pytest.mark.xfail()
 def test_remove_pkg(root, testapp):


### PR DESCRIPTION
Example output
```
$ pip search --index http://127.0.0.1:8092 pypiserver
pypiserver                - 1.2.0.dev1
  INSTALLED: 1.2.0.dev1 (latest)
$ pip search --index http://127.0.0.1:8092 pypiserver9
$ 

```

The two additional libs in use are both part of standard python.

However unit testing hasn't been added yet. Trying to figure out how to get WebTest to understand and send xml