### PR TITLE
Fix documentation for starting pypiserver with gunicorn

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -436,11 +436,11 @@ gunicorn
 
 The following command uses *gunicorn* to start *pypiserver*::
 
-  gunicorn -w4 'pypiserver:app("/home/ralf/packages")'
+  gunicorn -w4 'pypiserver:app(root="/home/ralf/packages")'
 
 or when using multiple roots::
 
-  gunicorn -w4 'pypiserver:app(["/home/ralf/packages", "/home/ralf/experimental"])'
+  gunicorn -w4 'pypiserver:app(root=["/home/ralf/packages", "/home/ralf/experimental"])'
 
 
 apache/mod_wsgi


### PR DESCRIPTION
The documentation in `README.rst` for running pypiserver via gunicorn uses an example with positional arguments to pypiserver:app(), however this throws errors:
  
    $ gunicorn --error-logfile=- 'pypiserver:app("/var/build/wheels")'
    <snip>
    Traceback (most recent call last):
      File "/opt/pypiserver/1.1.10/local/lib/python2.7/site-packages/gunicorn/arbiter.py", line 515, in spawn_worker
        worker.init_process()
      File "/opt/pypiserver/1.1.10/local/lib/python2.7/site-packages/gunicorn/workers/base.py", line 122, in init_process
        self.load_wsgi()
      File "/opt/pypiserver/1.1.10/local/lib/python2.7/site-packages/gunicorn/workers/base.py", line 130, in load_wsgi
        self.wsgi = self.app.wsgi()
      File "/opt/pypiserver/1.1.10/local/lib/python2.7/site-packages/gunicorn/app/base.py", line 67, in wsgi
        self.callable = self.load()
      File "/opt/pypiserver/1.1.10/local/lib/python2.7/site-packages/gunicorn/app/wsgiapp.py", line 65, in load
        return self.load_wsgiapp()
      File "/opt/pypiserver/1.1.10/local/lib/python2.7/site-packages/gunicorn/app/wsgiapp.py", line 52, in load_wsgiapp
        return util.import_app(self.app_uri)
      File "/opt/pypiserver/1.1.10/local/lib/python2.7/site-packages/gunicorn/util.py", line 368, in import_app
        app = eval(obj, mod.__dict__)
      File "<string>", line 1, in <module>
    TypeError: app() takes exactly 0 arguments (1 given)
    [2016-03-10 14:12:53 +0000] [6930] [INFO] Worker exiting (pid: 6930)
    Traceback (most recent call last):
      File "./bin/gunicorn", line 11, in <module>
        sys.exit(run())
      File "/opt/pypiserver/1.1.10/local/lib/python2.7/site-packages/gunicorn/app/wsgiapp.py", line 74, in run
        WSGIApplication("%(prog)s [OPTIONS] [APP_MODULE]").run()
      File "/opt/pypiserver/1.1.10/local/lib/python2.7/site-packages/gunicorn/app/base.py", line 192, in run
        super(Application, self).run()
      File "/opt/pypiserver/1.1.10/local/lib/python2.7/site-packages/gunicorn/app/base.py", line 72, in run
        Arbiter(self).run()
      File "/opt/pypiserver/1.1.10/local/lib/python2.7/site-packages/gunicorn/arbiter.py", line 206, in run
        self.halt(reason=inst.reason, exit_status=inst.exit_status)
      File "/opt/pypiserver/1.1.10/local/lib/python2.7/site-packages/gunicorn/arbiter.py", line 302, in halt
        self.stop()
      File "/opt/pypiserver/1.1.10/local/lib/python2.7/site-packages/gunicorn/arbiter.py", line 347, in stop
        time.sleep(0.1)
      File "/opt/pypiserver/1.1.10/local/lib/python2.7/site-packages/gunicorn/arbiter.py", line 219, in handle_chld
        self.reap_workers()
      File "/opt/pypiserver/1.1.10/local/lib/python2.7/site-packages/gunicorn/arbiter.py", line 464, in reap_workers
        raise HaltServer(reason, self.WORKER_BOOT_ERROR)
    gunicorn.errors.HaltServer: <HaltServer 'Worker failed to boot.' 3>

The problem appears to be that `app()` only accepts keyword args, rather than positional args:

    def app(**kwds):

By adjusting the startup command to pass `root=` via `app()` gunicorn is able to start pypiserver:

    $ gunicorn --error-logfile=- 'pypiserver:app(root="/var/build/wheels")'
    <snip>
    [2016-03-10 14:14:10 +0000] [6974] [INFO] Starting gunicorn 19.4.5
    [2016-03-10 14:14:10 +0000] [6974] [DEBUG] Arbiter booted
    [2016-03-10 14:14:10 +0000] [6974] [INFO] Listening at: http://127.0.0.1:8080 (6974)
    [2016-03-10 14:14:10 +0000] [6974] [INFO] Using worker: sync
    [2016-03-10 14:14:10 +0000] [6979] [INFO] Booting worker with pid: 6979
    [2016-03-10 14:14:10 +0000] [6980] [INFO] Booting worker with pid: 6980
    [2016-03-10 14:14:10 +0000] [6981] [INFO] Booting worker with pid: 6981
    [2016-03-10 14:14:10 +0000] [6974] [DEBUG] 3 workers

This also works for the list form to provide multiple roots:

    $ gunicorn --error-logfile=- 'pypiserver:app(root=["/var/build/wheels", "/tmp"])'
    <snip>
    [2016-03-10 14:14:57 +0000] [7038] [INFO] Starting gunicorn 19.4.5
    [2016-03-10 14:14:57 +0000] [7038] [DEBUG] Arbiter booted
    [2016-03-10 14:14:57 +0000] [7038] [INFO] Listening at: http://127.0.0.1:8080 (7038)
    [2016-03-10 14:14:57 +0000] [7038] [INFO] Using worker: sync
    [2016-03-10 14:14:57 +0000] [7043] [INFO] Booting worker with pid: 7043
    [2016-03-10 14:14:58 +0000] [7044] [INFO] Booting worker with pid: 7044
    [2016-03-10 14:14:58 +0000] [7045] [INFO] Booting worker with pid: 7045
    [2016-03-10 14:14:58 +0000] [7038] [DEBUG] 3 workers

This pull request updates the `README.rst` file to correctly document starting pypiserver with gunicorn.
