### PR TITLE
Added passlib version specification (#120)

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -65,9 +65,10 @@ Instead of copying packages directly to the server's folder,
 you may also upload them remotely with a ``python setup.py upload`` command.
 Currently only password-protected uploads are supported!
 
-#. First make sure you have the *passlib* module installed,
-   which is needed for parsing the apache *htpasswd* file specified by
-   the `-P`, `--passwords` option (see next steps)::
+#. First make sure you have the *passlib* module installed (note that
+   `passlib>=1.6` is required), which is needed for parsing the apache
+   *htpasswd* file specified by the `-P`, `--passwords` option
+   (see next steps)::
 
      pip install passlib
 

--- a/requirements/dev.pip
+++ b/requirements/dev.pip
@@ -8,7 +8,7 @@
 pip>=7
 setuptools
 setuptools-git>=0.3
-passlib
+passlib>=1.6
 tox
 wheel>=0.25.0
 pytest>=2.3

--- a/setup.py
+++ b/setup.py
@@ -9,12 +9,13 @@ if sys.version_info >= (3, 0):
 else:
     exec("def do_exec(co, loc): exec co in loc\n")
 
-tests_require = ['pytest>=2.3', 'tox', 'twine', 'pip>=7', 'passlib', 'webtest']
+tests_require = ['pytest>=2.3', 'tox', 'twine', 'pip>=7',
+                 'passlib>=1.6', 'webtest']
 if sys.version_info <= (3, 2):
     tests_require.append('mock')
 
 setup_requires = ['setuptools', 'setuptools-git >= 0.3']
-if sys.version_info >= (3,5):
+if sys.version_info >= (3, 5):
     setup_requires.append('wheel >= 0.25.0')  # earlier wheels fail in 3.5
 else:
     setup_requires.append('wheel')
@@ -37,7 +38,7 @@ setup(name="pypiserver",
       package_data={'pypiserver': ['welcome.html']},
       setup_requires=setup_requires,
       extras_require={
-          'passlib': ['passlib'],
+          'passlib': ['passlib>=1.6'],
           'cache': ['watchdog']
       },
       tests_require=tests_require,


### PR DESCRIPTION
Issue #120 showed that passlib>=1.6 is required for proper functioning of package uploads. The `passlib` extra now explicitly requires this.

Also includes a small PEP 008 whitespace change in line 18 of `setup.py`.