### PR TITLE
Fix typo, the package name is pypiserver

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -395,7 +395,7 @@ pypiserver's directory caching functionality. The only requirement is to
 install the ``watchdog`` package, or it can be installed by installing
 ``pypiserver`` using the ``cache`` extras option::
 
-  pip install pypi-server[cache]
+  pip install pypiserver[cache]
 
 If you are using a static webserver such as *Apache* or *nginx* as
 a reverse-proxy for pypiserver, additional speedup can be gained by


### PR DESCRIPTION
Fix typo, the package name in pypi is pypiserver and not pypi-server.