### PR TITLE
FIX #124: Convert forgotten attr-access-->dict-access.

### DIFF
--- a/pypiserver/__init__.py
+++ b/pypiserver/__init__.py
@@ -131,13 +131,13 @@ def app(**kwds):
 def str2bool(s, default):
     if s is not None and s != '':
         return s.lower() not in ("no", "off", "0", "false")
-        return default
+    return default
 
 def paste_app_factory(global_config, **local_conf):
     import os
 
-    def upd_bool_attr_from_dict_str_item(conf, attr, sdict):
-        setattr(conf, attr, str2bool(sdict.pop(attr, None), getattr(conf, attr)))
+    def upd_conf_with_bool_item(conf, attr, sdict):
+        conf[attr] = str2bool(sdict.pop(attr, None), conf[attr])
 
     def _make_root(root):
         root = root.strip()
@@ -151,8 +151,8 @@ def paste_app_factory(global_config, **local_conf):
     if root:
         c['root'] = [_make_root(x) for x in root.split("\n") if x.strip()]
 
-    upd_bool_attr_from_dict_str_item(c, 'redirect_to_fallback', local_conf)
-    upd_bool_attr_from_dict_str_item(c, 'overwrite', local_conf)
+    upd_conf_with_bool_item(c, 'redirect_to_fallback', local_conf)
+    upd_conf_with_bool_item(c, 'overwrite', local_conf)
 
     return app(**vars(c))
 

--- a/pypiserver/__init__.py
+++ b/pypiserver/__init__.py
@@ -154,7 +154,7 @@ def paste_app_factory(global_config, **local_conf):
     upd_conf_with_bool_item(c, 'redirect_to_fallback', local_conf)
     upd_conf_with_bool_item(c, 'overwrite', local_conf)
 
-    return app(**vars(c))
+    return app(**c)
 
 def _logwrite(logger, level, msg):
     if msg:

--- a/pypiserver/__init__.py
+++ b/pypiserver/__init__.py
@@ -149,7 +149,7 @@ def paste_app_factory(global_config, **local_conf):
 
     root = local_conf.get("root")
     if root:
-        c.root = [_make_root(x) for x in root.split("\n") if x.strip()]
+        c['root'] = [_make_root(x) for x in root.split("\n") if x.strip()]
 
     upd_bool_attr_from_dict_str_item(c, 'redirect_to_fallback', local_conf)
     upd_bool_attr_from_dict_str_item(c, 'overwrite', local_conf)

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -1,0 +1,39 @@
+"""
+Test module for . . .
+"""
+# Standard library imports
+from __future__ import (absolute_import, division,
+                        print_function, unicode_literals)
+import logging
+from os.path import abspath, dirname, join, realpath, relpath
+from sys import path
+
+# Third party imports
+import pytest
+
+# Local imports
+
+logger = logging.getLogger(__name__)
+
+test_dir = realpath(dirname(__file__))
+src_dir = abspath(join(test_dir, '..'))
+path.append(src_dir)
+print(path)
+
+import pypiserver
+
+
+@pytest.mark.parametrize('conf_options', [
+    {},
+    {'root': '~/stable_packages'},
+    {'root': '~/unstable_packages', 'authenticated': 'upload',
+     'passwords': '~/htpasswd'}
+])
+def test_paste_app_factory(conf_options, monkeypatch):
+    """Test the paste_app_factory method"""
+    monkeypatch.setattr('pypiserver.core.configure',
+                        lambda **x: (x, [x.keys()]))
+    pypiserver.paste_app_factory({}, **conf_options)
+
+
+


### PR DESCRIPTION
Incorporated changes from @ankostis PR #127 and added a test that fails on current master with the same error message as in #124, but succeeds with changed code.

Test fails with the following error message, as seen in #124:

````
(Python35)[Nautilus@Nautilus-2 pypiserver]$ py.test tests/test_init.py 
====================================================================================== test session starts ======================================================================================
platform darwin -- Python 3.5.0, pytest-2.8.7, py-1.4.31, pluggy-0.3.1
rootdir: /Users/Nautilus/Documents/Programming/ihiji/pypiserver, inifile: tox.ini
plugins: cov-2.2.1
collected 3 items 

tests/test_init.py FFF

=========================================================================================== FAILURES ============================================================================================
_____________________________________________________________________________ test_paste_app_factory[conf_options0] _____________________________________________________________________________

conf_options = {}

    @pytest.mark.parametrize('conf_options', [
        {},
        {'root': '~/stable_packages'},
        {'root': '~/unstable_packages', 'authenticated': 'upload',
         'passwords': '~/htpasswd'}
    ])
    def test_paste_app_factory(conf_options):
        """Test the paste_app_factory method"""
>       res_app = pypiserver.paste_app_factory({}, **conf_options)

tests/test_init.py:26: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _
../../Python35/lib/python3.5/site-packages/pypiserver/__init__.py:154: in paste_app_factory
    upd_bool_attr_from_dict_str_item(c, 'redirect_to_fallback', local_conf)
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _

conf = {'VERSION': '1.1.10', 'authenticated': ['update'], 'auther': None, 'cache_control': None, ...}, attr = 'redirect_to_fallback', sdict = {}

    def upd_bool_attr_from_dict_str_item(conf, attr, sdict):
>       setattr(conf, attr, str2bool(sdict.pop(attr, None), getattr(conf, attr)))
E       AttributeError: 'dict' object has no attribute 'redirect_to_fallback'

../../Python35/lib/python3.5/site-packages/pypiserver/__init__.py:140: AttributeError
_____________________________________________________________________________ test_paste_app_factory[conf_options1] _____________________________________________________________________________

conf_options = {'root': '~/stable_packages'}

    @pytest.mark.parametrize('conf_options', [
        {},
        {'root': '~/stable_packages'},
        {'root': '~/unstable_packages', 'authenticated': 'upload',
         'passwords': '~/htpasswd'}
    ])
    def test_paste_app_factory(conf_options):
        """Test the paste_app_factory method"""
>       res_app = pypiserver.paste_app_factory({}, **conf_options)

tests/test_init.py:26: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _

global_config = {}, local_conf = {'root': '~/stable_packages'}, upd_bool_attr_from_dict_str_item = <function paste_app_factory.<locals>.upd_bool_attr_from_dict_str_item at 0x103848d08>
c = {'VERSION': '1.1.10', 'authenticated': ['update'], 'auther': None, 'cache_control': None, ...}, root = '~/stable_packages'

    def paste_app_factory(global_config, **local_conf):
        import os
    
        def upd_bool_attr_from_dict_str_item(conf, attr, sdict):
            setattr(conf, attr, str2bool(sdict.pop(attr, None), getattr(conf, attr)))
    
        def _make_root(root):
            root = root.strip()
            if root.startswith("~"):
                return os.path.expanduser(root)
            return root
    
        c = default_config()
    
        root = local_conf.get("root")
        if root:
>           c.root = [_make_root(x) for x in root.split("\n") if x.strip()]
E           AttributeError: 'dict' object has no attribute 'root'

../../Python35/lib/python3.5/site-packages/pypiserver/__init__.py:152: AttributeError
_____________________________________________________________________________ test_paste_app_factory[conf_options2] _____________________________________________________________________________

conf_options = {'authenticated': 'upload', 'passwords': '~/htpasswd', 'root': '~/unstable_packages'}

    @pytest.mark.parametrize('conf_options', [
        {},
        {'root': '~/stable_packages'},
        {'root': '~/unstable_packages', 'authenticated': 'upload',
         'passwords': '~/htpasswd'}
    ])
    def test_paste_app_factory(conf_options):
        """Test the paste_app_factory method"""
>       res_app = pypiserver.paste_app_factory({}, **conf_options)

tests/test_init.py:26: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _

global_config = {}, local_conf = {'authenticated': 'upload', 'passwords': '~/htpasswd', 'root': '~/unstable_packages'}
upd_bool_attr_from_dict_str_item = <function paste_app_factory.<locals>.upd_bool_attr_from_dict_str_item at 0x1038710d0>
c = {'VERSION': '1.1.10', 'authenticated': ['update'], 'auther': None, 'cache_control': None, ...}, root = '~/unstable_packages'

    def paste_app_factory(global_config, **local_conf):
        import os
    
        def upd_bool_attr_from_dict_str_item(conf, attr, sdict):
            setattr(conf, attr, str2bool(sdict.pop(attr, None), getattr(conf, attr)))
    
        def _make_root(root):
            root = root.strip()
            if root.startswith("~"):
                return os.path.expanduser(root)
            return root
    
        c = default_config()
    
        root = local_conf.get("root")
        if root:
>           c.root = [_make_root(x) for x in root.split("\n") if x.strip()]
E           AttributeError: 'dict' object has no attribute 'root'

../../Python35/lib/python3.5/site-packages/pypiserver/__init__.py:152: AttributeError
=================================================================================== 3 failed in 0.05 seconds ====================================================================================
````