### PR TITLE
PEP 503 Package Name Normalization and URL Redirects

### DIFF
--- a/pypiserver/core.py
+++ b/pypiserver/core.py
@@ -181,7 +181,8 @@ def guess_pkgname_and_version(path):
 
 
 def normalize_pkgname(name):
-    return name.lower().replace("-", "_")
+    """Perform PEP 503 normalization"""
+    return re.sub(r"[-_.]+", "-", name).lower()
 
 
 def is_allowed_path(path_part):
@@ -258,23 +259,11 @@ def find_packages(pkgs, prefix=""):
 
 
 def get_prefixes(pkgs):
-    pkgnames = set()
     normalized_pkgnames = set()
-    eggs = set()
-
     for x in pkgs:
         if x.pkgname:
-            if x.relfn.endswith(".egg"):
-                eggs.add(x.pkgname)
-            else:
-                pkgnames.add(x.pkgname)
-                normalized_pkgnames.add(x.pkgname_norm)
-
-    for x in eggs:
-        if x not in normalized_pkgnames:
-            pkgnames.add(x)
-
-    return pkgnames
+            normalized_pkgnames.add(x.pkgname_norm)
+    return normalized_pkgnames
 
 
 def exists(root, filename):


### PR DESCRIPTION
PEP 503 addresses #139 (and also #38, which was I believe actual motivation of the PEP...) .

This PR makes the following changes to bring pypiserver up to spec:
- URLs are redirected unless they end in `/` (expect packages themselves).
- Package names are normalized: lowercase with all runs of the characters `.` , `-` , or `_` replaced with a single `-` character.
- The simple index only lists normalized package names.
- Any request for a non-normalized package name is redirected to the normalized name.

Note that pip >=8.1.2 will only request normalized package names. Apparently this change was intended to be in 8.0.0, but an implementation bug did not apply normalization correctly so that packages with dots (`.`) were requested unnormalized.

Tests added / updated.