### PR TITLE
Feature/auther via cmd option

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -688,7 +688,7 @@ these steps:
     import pypiserver
     from pypiserver import bottle
     import pam
-    pypiserver.app(root='./packages', auther=pam.authenticate)
+    app = pypiserver.app(root='./packages', auther=pam.authenticate)
     bottle.run(app=app, host='0.0.0.0', port=80, server='auto')
 
     [Ctrl+ D]

--- a/README.rst
+++ b/README.rst
@@ -258,11 +258,11 @@ In that case, *pypiserver* is responsible for authenticating the upload-requests
 
          http://www.htaccesstools.com/htpasswd-generator/
 
-   .. Tip:: When accessing pypiserver via the api, alternate authentication
-      methods are available via the ``auther`` config flag. Any callable
-      returning a boolean can be passed through to the pypiserver config in
-      order to provide custom authentication. For example, to configure
-      pypiserver to authenticate using the `python-pam`_::
+   .. Tip:: Alternate authentication methods are available via the ``auther``
+      config flag of ``pypiserver.api`` or via the ``--auther`` command line
+      option. Any callable returning a boolean can be passed through to the
+      pypiserver config in order to provide custom authentication. For example,
+      to configure pypiserver to authenticate using the `python-pam`_::
 
         import pam
         pypiserver.default_config(auther=pam.authenticate)

--- a/pypiserver/__main__.py
+++ b/pypiserver/__main__.py
@@ -7,6 +7,7 @@
 from __future__ import print_function
 
 import getopt
+import importlib
 import logging
 import os
 import re
@@ -119,6 +120,12 @@ def usage():
       Add "Cache-Control: max-age=AGE, public" header to package downloads.
       Pip 6+ needs this for caching.
 
+    --auther AUTHER
+      ad-hoc authentication provider to delegate authentication upon Python
+      callable object such as pam.authenticate provided by python-pam. As
+      pypi-server passes username and password, the callable shall return bool
+      value as an authentication result.
+
 
   pypi-server -h
   pypi-server --help
@@ -182,6 +189,7 @@ def main(argv=None):
             "log-err-frmt=",
             "welcome=",
             "cache-control=",
+            "auther=",
             "version",
             "help"
         ])
@@ -235,7 +243,7 @@ def main(argv=None):
             c.password_file = v
         elif k in ("-o", "--overwrite"):
             c.overwrite = True
-        elif k in ("--hash-algo"):
+        elif k == "--hash-algo":
             c.hash_algo = None if not pypiserver.str2bool(v, c.hash_algo) else v
         elif k == "--log-file":
             c.log_file = v
@@ -249,6 +257,19 @@ def main(argv=None):
             c.log_err_frmt = v
         elif k == "--cache-control":
             c.cache_control = v
+        elif k == "--auther":
+            try:
+                mod, _, func = v.rpartition(".")
+                if mod:
+                    c.auther = getattr(importlib.import_module(mod), func)
+                else:
+                    c.auther = globals()[func]
+            except ImportError:
+                err = sys.exc_info()[1]
+                sys.exit("Module(%r) is not available: %s" % (mod, err))
+            except (KeyError, AttributeError):
+                err = sys.exc_info()[1]
+                sys.exit("Callable(%r) is not available: %s" % (func, err))
         elif k == "-v":
             c.verbosity += 1
         elif k in ("-h", "--help"):

--- a/requirements/dev.pip
+++ b/requirements/dev.pip
@@ -15,7 +15,7 @@ pytest>=2.3
 webtest;        python_version != '2.5'
 mock;           python_version <= '3.2'
 gevent>=1.1b4;  python_version >= '3'
-twine>=1.7
+twine>=1.7,<=1.7.4
 
 WebOb==0.9.6.1;         python_version == '2.5'
 BeautifulSoup==3.2.1;   python_version == '2.5'

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -114,6 +114,9 @@ def test_hash_algo_BAD(main):
     #assert excinfo.value.message == 'some info'     main(['--hash-algo BAD'])
     print(excinfo)
 
+def test_auther(main):
+    main(['--auther=os.path.join'])
+    assert callable(main.app.module.config.auther)
 
 def test_logging(main, tmpdir):
     logfile = tmpdir.mkdir("logs").join('test.log')


### PR DESCRIPTION
Because I'd like to use pypiserver with own auth provider via `python -m pypiserver`, I had motivation to introduce new command line option named `--auther`. FYI: I also fixed small problems eventually brought to me when preparing this pull-request.