### PR TITLE
propagate configuration from paste.ini

### DIFF
--- a/pypiserver/__init__.py
+++ b/pypiserver/__init__.py
@@ -143,6 +143,21 @@ def paste_app_factory(global_config, **local_conf):
     def upd_conf_with_bool_item(conf, attr, sdict):
         conf[attr] = str2bool(sdict.pop(attr, None), conf[attr])
 
+    def upd_conf_with_str_item(conf, attr, sdict):
+        value = sdict.pop(attr, None)
+        if value is not None:
+            conf[attr] = value
+
+    def upd_conf_with_int_item(conf, attr, sdict):
+        value = sdict.pop(attr, None)
+        if value is not None:
+            conf[attr] = int(value)
+
+    def upd_conf_with_list_item(conf, attr, sdict, sep=' ', parse=str.strip):
+        values = sdict.pop(attr, None)
+        if values:
+            conf[attr] = list(filter(None, map(parse, values.split(sep))))
+
     def _make_root(root):
         root = root.strip()
         if root.startswith("~"):
@@ -151,12 +166,23 @@ def paste_app_factory(global_config, **local_conf):
 
     c = default_config()
 
-    root = local_conf.get("root")
-    if root:
-        c['root'] = [_make_root(x) for x in root.split("\n") if x.strip()]
-
+    upd_conf_with_list_item(c, 'root', local_conf, sep='\n', parse=_make_root)
     upd_conf_with_bool_item(c, 'redirect_to_fallback', local_conf)
+    upd_conf_with_str_item(c, 'fallback_url', local_conf)
+    upd_conf_with_list_item(c, 'authenticated', local_conf, sep=' ')
+    upd_conf_with_str_item(c, 'password_file', local_conf)
     upd_conf_with_bool_item(c, 'overwrite', local_conf)
+    upd_conf_with_str_item(c, 'hash_algo', local_conf)
+    upd_conf_with_int_item(c, 'verbosity', local_conf)
+    upd_conf_with_str_item(c, 'log_file', local_conf)
+    upd_conf_with_str_item(c, 'log_frmt', local_conf)
+    upd_conf_with_str_item(c, 'log_req_frmt', local_conf)
+    upd_conf_with_str_item(c, 'log_res_frmt', local_conf)
+    upd_conf_with_str_item(c, 'log_err_frmt', local_conf)
+    upd_conf_with_str_item(c, 'welcome_file', local_conf)
+    # cache_control is undocumented; don't know what type is expected:
+    # upd_conf_with_str_item(c, 'cache_control', local_conf)
+    print(c)
 
     return app(**c)
 

--- a/pypiserver/__init__.py
+++ b/pypiserver/__init__.py
@@ -139,6 +139,8 @@ def str2bool(s, default):
 
 def paste_app_factory(global_config, **local_conf):
     import os
+    # let's get unicode.strip in Python 2 or str.strip in Python 3:
+    str_strip = type(u"").strip
 
     def upd_conf_with_bool_item(conf, attr, sdict):
         conf[attr] = str2bool(sdict.pop(attr, None), conf[attr])
@@ -153,7 +155,7 @@ def paste_app_factory(global_config, **local_conf):
         if value is not None:
             conf[attr] = int(value)
 
-    def upd_conf_with_list_item(conf, attr, sdict, sep=' ', parse=str.strip):
+    def upd_conf_with_list_item(conf, attr, sdict, sep=' ', parse=str_strip):
         values = sdict.pop(attr, None)
         if values:
             conf[attr] = list(filter(None, map(parse, values.split(sep))))

--- a/pypiserver/__init__.py
+++ b/pypiserver/__init__.py
@@ -168,23 +168,26 @@ def paste_app_factory(global_config, **local_conf):
 
     c = default_config()
 
-    upd_conf_with_list_item(c, 'root', local_conf, sep='\n', parse=_make_root)
-    upd_conf_with_bool_item(c, 'redirect_to_fallback', local_conf)
-    upd_conf_with_str_item(c, 'fallback_url', local_conf)
-    upd_conf_with_list_item(c, 'authenticated', local_conf, sep=' ')
-    upd_conf_with_str_item(c, 'password_file', local_conf)
     upd_conf_with_bool_item(c, 'overwrite', local_conf)
-    upd_conf_with_str_item(c, 'hash_algo', local_conf)
+    upd_conf_with_bool_item(c, 'redirect_to_fallback', local_conf)
+    upd_conf_with_list_item(c, 'authenticated', local_conf, sep=' ')
+    upd_conf_with_list_item(c, 'root', local_conf, sep='\n', parse=_make_root)
     upd_conf_with_int_item(c, 'verbosity', local_conf)
-    upd_conf_with_str_item(c, 'log_file', local_conf)
-    upd_conf_with_str_item(c, 'log_frmt', local_conf)
-    upd_conf_with_str_item(c, 'log_req_frmt', local_conf)
-    upd_conf_with_str_item(c, 'log_res_frmt', local_conf)
-    upd_conf_with_str_item(c, 'log_err_frmt', local_conf)
-    upd_conf_with_str_item(c, 'welcome_file', local_conf)
+    str_items = [
+        'fallback_url',
+        'hash_algo',
+        'log_err_frmt',
+        'log_file',
+        'log_frmt',
+        'log_req_frmt',
+        'log_res_frmt',
+        'password_file',
+        'welcome_file'
+    ]
+    for str_item in str_items:
+        upd_conf_with_str_item(c, str_item, local_conf)
     # cache_control is undocumented; don't know what type is expected:
     # upd_conf_with_str_item(c, 'cache_control', local_conf)
-    print(c)
 
     return app(**c)
 


### PR DESCRIPTION
This is a rebased version of #156, which reads:

----

Here's an example paste.ini:

```
[composite:main]
use = egg:Paste#urlmap
/pypi/ = pypiserver

[app:pypiserver]
use = egg:pypiserver#main
root = %(here)s/packages
authenticated = list update download
redirect_to_fallback = False
password_file = %(here)s/htpasswd.txt
log_file = %(here)s/log.txt
verbosity = 2

[server:main]
use = egg:gunicorn#main
host = 127.0.0.1
port = 8001
workers = 4
accesslog = %(here)s/accesslog.txt
```

The following configuration keywords were not being propagated into the app:

```
authenticated = list update download
password_file = %(here)s/htpasswd.txt
log_file = %(here)s/log.txt
verbosity = 2
```

Now it works.
Hope you like the code.
I tried to keep same style. 
