### PR TITLE
Allow creating multiple servers using Paste

### DIFF
--- a/pypiserver/__init__.py
+++ b/pypiserver/__init__.py
@@ -1,4 +1,5 @@
 import re as _re
+import sys
 
 version = __version__ = "1.2.1.dev0"
 __version_info__ = tuple(_re.split('[.-]', __version__))
@@ -120,7 +121,10 @@ def app(**kwds):
         :func:`default_config()`. Check the docstring of this function
         for supported kwds.
     """
-    from . import core, _app
+    from . import core
+
+    _app = __import__("_app", globals(), locals(), ["."], 1)
+    sys.modules.pop('pypiserver._app', None)
 
     kwds = default_config(**kwds)
     config, packages = core.configure(**kwds)

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -35,5 +35,7 @@ def test_paste_app_factory(conf_options, monkeypatch):
                         lambda **x: (x, [x.keys()]))
     pypiserver.paste_app_factory({}, **conf_options)
 
-
-
+def test_app_factory(monkeypatch):
+    monkeypatch.setattr('pypiserver.core.configure',
+                        lambda **x: (x, [x.keys()]))
+    assert pypiserver.app() is not pypiserver.app()


### PR DESCRIPTION
This brings back the import hack that allows one to use Paste urlmap to
compose multipe PyPi servers within a single WSGI server.

After importing _app, we remove it from sys.modules so that future
imports will have their own copy, this allows globals to function
correctly and each _app to have their own variables.

Closes: https://github.com/pypiserver/pypiserver/issues/167