### PR TITLE
Default fallback_url to use HTTPS

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,6 +34,12 @@ __pycache__/
 /parts/
 /.cache/
 /.settings/
+.mypy_cache/
 
 # IDE stuff
 .idea/
+
+# Venvs
+.venv/
+venv/
+

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,19 +1,20 @@
-sudo: travis
+sudo: false
 language: python
-python: 3.5
-env:
-  - TOX_ENV=py27
-  - TOX_ENV=py33
-  - TOX_ENV=py34
-  - TOX_ENV=py35
-  - TOX_ENV=pypy
+python:
+  - 2.7
+  - 3.3
+  - 3.4
+  - 3.5
+  - 3.6
+  - pypy
+  - pypy3
 
 install:
-  - pip install -U setuptools pip sphinx tox
+  - pip install -U setuptools pip sphinx tox tox-travis
 
 script:
   - ./bin/test_standalone.sh
-  - tox -e $TOX_ENV
+  - tox
   - ./bin/check_readme.sh
 
 branches:

--- a/README.rst
+++ b/README.rst
@@ -117,7 +117,7 @@ For legacy python versions, use ``pypiserver-1.1.x`` series.
 
       --fallback-url FALLBACK_URL
         for packages not found in the local index, this URL will be used to
-        redirect to (default: http://pypi.python.org/simple)
+        redirect to (default: https://pypi.python.org/simple)
 
       --server METHOD
         use METHOD to run the server. Valid values include paste,
@@ -413,10 +413,10 @@ looks like::
     no releases found on pypi for PyXML, Pymacs, mercurial, setuptools
 
     # update raven from 1.4.3 to 1.4.4
-    pip -q install --no-deps  --extra-index-url http://pypi.python.org/simple -d /home/ralf/packages/mirror raven==1.4.4
+    pip -q install --no-deps  --extra-index-url https://pypi.python.org/simple -d /home/ralf/packages/mirror raven==1.4.4
 
     # update greenlet from 0.3.3 to 0.3.4
-    pip -q install --no-deps  --extra-index-url http://pypi.python.org/simple -d /home/ralf/packages/mirror greenlet==0.3.4
+    pip -q install --no-deps  --extra-index-url https://pypi.python.org/simple -d /home/ralf/packages/mirror greenlet==0.3.4
 
 It first prints for each package a single character after checking the
 available versions on pypi. A dot(`.`) means the package is up-to-date, ``'u'``
@@ -811,7 +811,7 @@ See the ``LICENSE.txt`` file.
 
 
 .. _bottle: http://bottlepy.org
-.. _PyPI: http://pypi.python.org
+.. _PyPI: https://pypi.python.org
 .. _twine: https://pypi.python.org/pypi/twine
 .. _pypi-uploader: https://pypi.python.org/pypi/pypi-uploader
 .. _python-pam: https://pypi.python.org/pypi/python-pam/

--- a/bin/gen-standalone.sh
+++ b/bin/gen-standalone.sh
@@ -22,7 +22,7 @@ wheel="./dist/pypiserver-*.whl"
 #   prepend it with a python-flashbang + some header-comments >= 10-lines
 #   so that ``head pypiserver*.py``behaves politely.
 #
-sudo update-ca-certificates
+sudo update-ca-certificates || echo "Failed updating certs (run on travis container?)"
 unzip -jo $wheel pypiserver/__main__.py -d ./dist
 zip -d $wheel pypiserver/__main__.py
 zip -mj $wheel ./dist/__main__.py

--- a/pypiserver/__main__.py
+++ b/pypiserver/__main__.py
@@ -76,7 +76,7 @@ def usage():
 
     --fallback-url FALLBACK_URL
       for packages not found in the local index, this URL will be used to
-      redirect to (default: http://pypi.python.org/simple)
+      redirect to (default: https://pypi.python.org/simple)
 
     --server METHOD
       use METHOD to run the server. Valid values include paste,

--- a/pypiserver/core.py
+++ b/pypiserver/core.py
@@ -68,7 +68,7 @@ def configure(**kwds):
             "Could not load welcome-file(%s)!", c.welcome_file, exc_info=1)
 
     if c.fallback_url is None:
-        c.fallback_url = "http://pypi.python.org/simple"
+        c.fallback_url = "https://pypi.python.org/simple"
 
     if c.hash_algo:
         try:

--- a/pypiserver/welcome.html
+++ b/pypiserver/welcome.html
@@ -16,5 +16,5 @@ easy_install -i {{URL}}simple/ PACKAGE
 or via the <a href="{{SIMPLE}}">simple</a> index.</p>
 
 <p>This instance is running version {{VERSION}} of the
-  <a href="http://pypi.python.org/pypi/pypiserver">pypiserver</a> software.</p>
+  <a href="https://pypi.python.org/pypi/pypiserver">pypiserver</a> software.</p>
 </body></html>

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -178,7 +178,7 @@ def test_fallback(root, _app, testapp):
     assert _app.config.redirect_to_fallback
     resp = testapp.get("/simple/pypiserver/", status=302)
     assert resp.headers[
-        "Location"] == "http://pypi.python.org/simple/pypiserver/"
+        "Location"] == "https://pypi.python.org/simple/pypiserver/"
 
 
 def test_no_fallback(root, _app, testapp):

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -313,7 +313,7 @@ def test_root_no_relative_paths(testpriv):
     resp = testpriv.get("/priv/")
     hrefs = [x["href"] for x in resp.html("a")]
     assert hrefs == ['/priv/packages/', '/priv/simple/',
-                     'http://pypi.python.org/pypi/pypiserver']
+                     'https://pypi.python.org/pypi/pypiserver']
 
 
 def test_simple_index_list_no_duplicates(root, testapp):

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -80,14 +80,14 @@ def test_root_r(main):
 
 
 def test_fallback_url(main):
-    main(["--fallback-url", "http://pypi.mirror/simple"])
-    assert main.app.module.config.fallback_url == "http://pypi.mirror/simple"
+    main(["--fallback-url", "https://pypi.mirror/simple"])
+    assert main.app.module.config.fallback_url == "https://pypi.mirror/simple"
 
 
 def test_fallback_url_default(main):
     main([])
     assert main.app.module.config.fallback_url == \
-        "http://pypi.python.org/simple"
+        "https://pypi.python.org/simple"
 
 
 def test_hash_algo_default(main):


### PR DESCRIPTION
`pypi.python.org/simple` will respond to HTTP requests with `403: SSL is required.`

This will change the default fallback_url to use HTTPS.  This should fix #179.