### PR TITLE
Add $scheme forwarding to example nginx configuration

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -671,6 +671,7 @@ Extend your nginx configuration::
 
       location / {
         proxy_set_header  Host $host:$server_port;
+        proxy_set_header  X-Forwarded-Proto $scheme;
         proxy_set_header  X-Real-IP $remote_addr;
         proxy_pass        http://pypi;
       }


### PR DESCRIPTION
Adding `X-Forwarded-Proto` makes bottle pick up on the original request's scheme (https/http), so that the URL on the welcome page is displayed correctly.