### PR TITLE
Release Tidying

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,9 +4,6 @@ Changelog
 1.2.1 (2017-11-29)
 ------------------
 
-- Matrix-based authorization, allowing users to have multiple actions
-  (thanks @khornberg, #132)
-
 - FIX propagation of certain ``pypiserver`` settings via a ``paste.ini`` config
   file (thanks @luismsgomes, #156)
 

--- a/README.rst
+++ b/README.rst
@@ -10,7 +10,7 @@ pypiserver - minimal PyPI server for use with pip/easy_install
 |pypi-ver| |travis-status| |dependencies| |downloads-count| |python-ver| \
 |proj-license|
 
-:Version:     1.2.1
+:Version:     1.2.2dev0
 :Date:        2017-11-29 11:49:30
 :Source:      https://github.com/pypiserver/pypiserver
 :PyPI:        https://pypi.python.org/pypi/pypiserver

--- a/pypiserver/__init__.py
+++ b/pypiserver/__init__.py
@@ -3,7 +3,7 @@ import sys
 
 version = __version__ = "1.2.1"
 __version_info__ = tuple(_re.split('[.-]', __version__))
-__updated__ = "2017-11-29 18:47:30"
+__updated__ = "2017-11-29 19:10:17"
 
 __title__ = "pypiserver"
 __summary__ = "A minimal PyPI server for use with pip/easy_install."

--- a/pypiserver/__init__.py
+++ b/pypiserver/__init__.py
@@ -1,9 +1,9 @@
 import re as _re
 import sys
 
-version = __version__ = "1.2.1"
+version = __version__ = "1.2.2dev0"
 __version_info__ = tuple(_re.split('[.-]', __version__))
-__updated__ = "2017-11-29 19:10:17"
+__updated__ = "2017-11-29 19:23:21"
 
 __title__ = "pypiserver"
 __summary__ = "A minimal PyPI server for use with pip/easy_install."


### PR DESCRIPTION
Noticed that I hadn't removed the changelog section about matrix authorization, and went ahead and popped the version up to 1.2.2dev0