### PR TITLE
Resolved paste config parsing issue for Python 2

### DIFF
--- a/pypiserver/__init__.py
+++ b/pypiserver/__init__.py
@@ -1,3 +1,4 @@
+import os
 import re as _re
 import sys
 
@@ -141,10 +142,13 @@ def str2bool(s, default):
     return default
 
 
+def _str_strip(string):
+    """Provide a generic strip method to pass as a callback."""
+    return string.strip()
+
+
 def paste_app_factory(global_config, **local_conf):
-    import os
-    # let's get unicode.strip in Python 2 or str.strip in Python 3:
-    str_strip = type(u"").strip
+    """Parse a paste config and return an app."""
 
     def upd_conf_with_bool_item(conf, attr, sdict):
         conf[attr] = str2bool(sdict.pop(attr, None), conf[attr])
@@ -159,7 +163,7 @@ def paste_app_factory(global_config, **local_conf):
         if value is not None:
             conf[attr] = int(value)
 
-    def upd_conf_with_list_item(conf, attr, sdict, sep=' ', parse=str_strip):
+    def upd_conf_with_list_item(conf, attr, sdict, sep=' ', parse=_str_strip):
         values = sdict.pop(attr, None)
         if values:
             conf[attr] = list(filter(None, map(parse, values.split(sep))))

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -27,7 +27,9 @@ import pypiserver
     {},
     {'root': '~/stable_packages'},
     {'root': '~/unstable_packages', 'authenticated': 'upload',
-     'passwords': '~/htpasswd'}
+     'passwords': '~/htpasswd'},
+    # Verify that the strip parser works properly.
+    {'authenticated': str('upload')},
 ])
 def test_paste_app_factory(conf_options, monkeypatch):
     """Test the paste_app_factory method"""


### PR DESCRIPTION
Resolves #125 

The ability to propagate configuration values from a paste config
file was introduced in #156. However, as pointed out in #125
by @redbaron4, the string strip method introduced in #156 was
problematic in Python 2.

This resolves that issue while also creating a test that fails
on the current master and passes with updates, demonstrating the
issue.