### PR TITLE
Drop support for EOL Python 3.3

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -32,9 +32,9 @@ with *scp*.
 
 Quickstart: Installation and Usage
 ==================================
-*pypiserver* ``> 1.2.x`` works with python ``2.7`` and ``3.3+`` or *pypy*.
-Older python-versions may still work, but they are not tested.
-For legacy python versions, use ``pypiserver-1.1.x`` series.
+*pypiserver* ``> 1.2.x`` works with Python ``2.7`` and ``3.4+`` or *pypy*.
+Older Python versions may still work, but they are not tested.
+For legacy Python versions, use ``pypiserver-1.1.x`` series.
 
 .. Tip::
    The commands below work on a unix-like operating system with a posix shell.

--- a/bootstrap.py
+++ b/bootstrap.py
@@ -51,7 +51,7 @@ parser.add_option("-c", "--config-file",
                    help=("Specify the path to the buildout configuration "
                          "file to be used."))
 parser.add_option("-f", "--find-links",
-                   help=("Specify a URL to search for buildout releases"))
+                  help="Specify a URL to search for buildout releases")
 
 
 options, args = parser.parse_args()

--- a/pypiserver/__main__.py
+++ b/pypiserver/__main__.py
@@ -233,7 +233,7 @@ def main(argv=None):
             c.password_file = v
         elif k in ("-o", "--overwrite"):
             c.overwrite = True
-        elif k in ("--hash-algo"):
+        elif k in "--hash-algo":
             c.hash_algo = None if not pypiserver.str2bool(v, c.hash_algo) else v
         elif k == "--log-file":
             c.log_file = v

--- a/pypiserver/__main__.py
+++ b/pypiserver/__main__.py
@@ -12,7 +12,6 @@ import os
 import re
 import sys
 import textwrap
-import warnings
 
 import functools as ft
 

--- a/pypiserver/__main__.py
+++ b/pypiserver/__main__.py
@@ -17,7 +17,6 @@ import warnings
 import functools as ft
 
 
-warnings.filterwarnings("ignore", "Python 2.5 support may be dropped in future versions of Bottle")
 log = logging.getLogger('pypiserver.main')
 
 

--- a/pypiserver/_app.py
+++ b/pypiserver/_app.py
@@ -34,7 +34,7 @@ app = Bottle()
 
 
 class auth(object):
-    "decorator to apply authentication if specified for the decorated method & action"
+    """decorator to apply authentication if specified for the decorated method & action"""
 
     def __init__(self, action):
         self.action = action

--- a/pypiserver/bottle.py
+++ b/pypiserver/bottle.py
@@ -1503,10 +1503,10 @@ class BaseResponse(object):
     # Header blacklist for specific response codes
     # (rfc2616 section 10.2.3 and 10.3.5)
     bad_headers = {
-        204: set(('Content-Type', )),
-        304: set(('Allow', 'Content-Encoding', 'Content-Language',
-                  'Content-Length', 'Content-Range', 'Content-Type',
-                  'Content-Md5', 'Last-Modified'))
+        204: {'Content-Type'},
+        304: {'Allow', 'Content-Encoding', 'Content-Language',
+              'Content-Length', 'Content-Range', 'Content-Type', 'Content-Md5',
+              'Last-Modified'}
     }
 
     def __init__(self, body='', status=None, headers=None, **more_headers):

--- a/pypiserver/bottle.py
+++ b/pypiserver/bottle.py
@@ -1380,7 +1380,7 @@ class BaseRequest(object):
         basic = parse_auth(self.environ.get('HTTP_AUTHORIZATION', ''))
         if basic: return basic
         ruser = self.environ.get('REMOTE_USER')
-        if ruser: return (ruser, None)
+        if ruser: return ruser, None
         return None
 
     @property

--- a/pypiserver/cache.py
+++ b/pypiserver/cache.py
@@ -9,20 +9,20 @@ from watchdog.observers import Observer
 import threading
 
 class CacheManager(object):
-    '''
+    """
         A naive cache implementation for listdir and digest_file
 
         The listdir_cache is just a giant list of PkgFile objects, and
         for simplicity it is invalidated anytime a modification occurs
-        within the directory it represents. If we were smarter about 
-        the way that the listdir data structure were created/stored, 
+        within the directory it represents. If we were smarter about
+        the way that the listdir data structure were created/stored,
         then we could do more granular invalidation. In practice, this
         is good enough for now.
 
         The digest_cache exists on a per-file basis, because computing
         hashes on large files can get expensive, and it's very easy to
         invalidate specific filenames.
-    '''
+    """
 
     def __init__(self):
 
@@ -92,7 +92,7 @@ class _EventHandler(object):
         self.root = root
 
     def dispatch(self, event):
-        '''Called by watchdog observer'''
+        """Called by watchdog observer"""
         cache = self.cache
 
         # Don't care about directory events

--- a/pypiserver/core.py
+++ b/pypiserver/core.py
@@ -1,7 +1,6 @@
 #! /usr/bin/env python
 """minimal PyPI like server for use with pip/easy_install"""
 
-from collections import namedtuple
 import functools
 import hashlib
 import io

--- a/requirements/dev.pip
+++ b/requirements/dev.pip
@@ -7,14 +7,13 @@
 
 docopt  # For `/bin/bumpver.py`.
 gevent>=1.1b4; python_version >= '3'
-mock; python_version <= '3.2'
+mock; python_version == '2.7'
 pip>=7
 passlib>=1.6
-pytest>=2.3; python_version != '3.3'
-pytest>=2.3,<3.3; python_version == '3.3'
+pytest>=2.3
 setuptools
 setuptools-git>=0.3
 tox
 twine>=1.7
-webtest; python_version != '2.5'
+webtest
 wheel>=0.25.0

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ else:
 
 tests_require = ['pytest>=2.3', 'tox', 'twine', 'pip>=7',
                  'passlib>=1.6', 'webtest']
-if sys.version_info <= (3, 2):
+if sys.version_info == (2, 7):
     tests_require.append('mock')
 
 setup_requires = ['setuptools', 'setuptools-git >= 0.3']
@@ -36,6 +36,7 @@ setup(name="pypiserver",
       version=get_version(),
       packages=["pypiserver"],
       package_data={'pypiserver': ['welcome.html']},
+      python_requires=">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*",
       setup_requires=setup_requires,
       extras_require={
           'passlib': ['passlib>=1.6'],
@@ -60,10 +61,10 @@ setup(name="pypiserver",
           "Programming Language :: Python :: 2",
           "Programming Language :: Python :: 2.7",
           "Programming Language :: Python :: 3",
-          "Programming Language :: Python :: 3.3",
           "Programming Language :: Python :: 3.4",
           "Programming Language :: Python :: 3.5",
           "Programming Language :: Python :: 3.6",
+          "Programming Language :: Python :: Implementation :: CPython",
           "Programming Language :: Python :: Implementation :: PyPy",
           "Topic :: Software Development :: Build Tools",
           "Topic :: System :: Software Distribution"],

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -349,7 +349,7 @@ def test_simple_index_list_name_with_underscore_no_egg(root, testapp):
     resp = testapp.get("/simple/")
     assert len(resp.html("a")) == 1
     hrefs = set([x["href"] for x in resp.html("a")])
-    assert hrefs == set(["foo-bar/"])
+    assert hrefs == {"foo-bar/"}
 
 
 def test_no_cache_control_set(root, _app, testapp):

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -381,9 +381,9 @@ def test_upload_badAction(root, testapp):
     assert "Unsupported ':action' field: BAD" in hp.unescape(resp.text)
 
 
-@pytest.mark.parametrize(("package"), [f[0] 
-        for f in test_core.files 
-        if f[1] and '/' not in f[0]])
+@pytest.mark.parametrize("package", [f[0]
+                                     for f in test_core.files
+                                     if f[1] and '/' not in f[0]])
 def test_upload(package, root, testapp):
     resp = testapp.post("/", params={':action': 'file_upload'},
             upload_files=[('content', package, b'')])
@@ -393,9 +393,9 @@ def test_upload(package, root, testapp):
     assert uploaded_pkgs[0].lower() == package.lower()
 
 
-@pytest.mark.parametrize(("package"), [f[0] 
-        for f in test_core.files 
-        if f[1] and '/' not in f[0]])
+@pytest.mark.parametrize("package", [f[0]
+                                     for f in test_core.files
+                                     if f[1] and '/' not in f[0]])
 def test_upload_with_signature(package, root, testapp):
     resp = testapp.post("/", params={':action': 'file_upload'},
             upload_files=[
@@ -408,7 +408,7 @@ def test_upload_with_signature(package, root, testapp):
     assert '%s.asc' % package.lower() in uploaded_pkgs
 
 
-@pytest.mark.parametrize(("package"), [
+@pytest.mark.parametrize("package", [
         f[0] for f in test_core.files
         if f[1] is None])
 def test_upload_badFilename(package, root, testapp):

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -5,7 +5,7 @@ Test module for . . .
 from __future__ import (absolute_import, division,
                         print_function, unicode_literals)
 import logging
-from os.path import abspath, dirname, join, realpath, relpath
+from os.path import abspath, dirname, join, realpath
 from sys import path
 
 # Third party imports


### PR DESCRIPTION
Fix #192.

Also remove some redundant code for Python < 2.7 and 3.0-3.2, and some minor tidy-ups.