### PR TITLE
Provide Prerelease Testing for Twine

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,6 @@ sudo: false
 language: python
 python:
   - 2.7
-  - 3.3
   - 3.4
   - 3.5
   - 3.6

--- a/requirements/dev.pip
+++ b/requirements/dev.pip
@@ -5,20 +5,16 @@
 
 -r exe.pip
 
+docopt  # For `/bin/bumpver.py`.
+gevent>=1.1b4; python_version >= '3'
+mock; python_version <= '3.2'
 pip>=7
+passlib>=1.6
+pytest>=2.3; python_version != '3.3'
+pytest>=2.3,<3.3; python_version == '3.3'
 setuptools
 setuptools-git>=0.3
-passlib>=1.6
 tox
-wheel>=0.25.0
-pytest>=2.3;        python_version != '3.3'
-pytest>=2.3,<3.3;   python_version == '3.3'
-webtest;        python_version != '2.5'
-mock;           python_version <= '3.2'
-gevent>=1.1b4;  python_version >= '3'
 twine>=1.7
-
-WebOb==0.9.6.1;         python_version == '2.5'
-BeautifulSoup==3.2.1;   python_version == '2.5'
-WebTest==1.4.3;         python_version == '2.5'
-docopt                  # For `/bin/bumpver.py`.
+webtest; python_version != '2.5'
+wheel>=0.25.0

--- a/tox.ini
+++ b/tox.ini
@@ -1,10 +1,24 @@
 [tox]
-envlist = py27,py33,py34,py35
+envlist = py27,py34,py35,py36,pypy,pypy3
 
 [testenv]
 deps=-r{toxinidir}/requirements/dev.pip
-commands=py.test []
+whitelist_externals=
+    /bin/sh
+commands=
+    /bin/sh -c "{env:PYPISERVER_SETUP_CMD:true}"
+    pytest []
 sitepackages=False
 
 [pytest]
 norecursedirs = bin parts develop-eggs eggs venv .* _* CVS {args}
+
+[testenv:pre_twine]
+# Allow calling ``tox -e pre_twine`` to test pypiserver with the most
+# recent prerelease of twine.
+whitelist_externals=
+    tox
+setenv=
+    PYPISERVER_SETUP_CMD=pip install --upgrade --pre --index-url https://test.pypi.org/simple/ --extra-index-url https://pypi.org/simple twine
+commands=
+    tox


### PR DESCRIPTION
Resolves #203
Related to pypa/twine#314

This commit adds an ``sh -c`` call, whose argument is the value of the
environment variable ``PYPISERVER_SETUP_CMD``, or ``true`` if that
variable is not set. This was specifically added to enable the
``pre_twine`` environment, which is provided to automatically test
pre-releases of twine, both for our use (e.g. #203) and for the use of
the twine maintainers (pypa/twine#314).

The capacity to specify an arbitrary setup command via an environment
variable may also wind up being useful in other cases in the future.

In addition, the envlist is updated to include only Python versions we
actually support.

This commit also alphabetizes the ``dev.pip`` requirements and rmeoves
specific requirements for testing using Python 2.5 (which we do not test
against anymore).