### PR TITLE
Remove version pins from buildout.cfg

### DIFF
--- a/buildout.cfg
+++ b/buildout.cfg
@@ -57,23 +57,3 @@ eggs =
     ${buildout:eggs}
 scripts =
     ipython
-
-
-[versions]
-passlib = 1.6.5
-waitress = 0.9
-zc.recipe.egg = 2.0.3
-
-
-WebOb = 1.6.5
-WebTest = 2.0.21
-py = 1.4.31
-pytest = 2.9.2
-
-# Required by:
-# WebTest==2.0.3
-six = 1.10.0
-Paste = 2.0.3
-PasteDeploy = 1.5.2
-gunicorn = 19.6.0
-yolk = 0.4.3


### PR DESCRIPTION
Probably no one is using this, since it hasn't been updated in five years, but even if they are, there's no reason to be using five year old version of packages. Removed the `[versions]` config section.

I've never used buildout, but this seems to be okay according to [their docs](http://www.buildout.org/en/latest/getting-started.html)