### PR TITLE
REL: 1.3.0

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,20 @@
 Changelog
 =========
 
+1.3.0 (2019-05-xx)
+------------------
+
+- ENH: pypiserver now consistently and correctly handles the `X-Forwarded-Host`
+  header to allow for alternative base URLs (#248, resolves #155, thanks
+  @kujyp for an excellent first-time contribution!)
+- DOC: significantly more information added to the `docker-compose.yml`
+  example, including recipes for various configuration options (thanks
+  @jetheurer for pointing out the errors in the existing docs!)
+- DOC: removed outdated suggestion to serve the packages data directly via
+  a webserver and replaced with information about setting up nginx
+  caching (thanks @RiceKab for bringing the issue to our attention)
+
+
 1.2.7 (2019-01-31)
 ------------------
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -9,10 +9,10 @@ Changelog
   @kujyp for an excellent first-time contribution!)
 - DOC: significantly more information added to the `docker-compose.yml`
   example, including recipes for various configuration options (thanks
-  @jetheurer for pointing out the errors in the existing docs!)
+  @jetheurer for pointing out the errors in the existing docs, #243!)
 - DOC: removed outdated suggestion to serve the packages data directly via
   a webserver and replaced with information about setting up nginx
-  caching (thanks @RiceKab for bringing the issue to our attention)
+  caching (thanks @RiceKab for bringing the issue to our attention, #232)
 
 
 1.2.7 (2019-01-31)

--- a/README.rst
+++ b/README.rst
@@ -10,7 +10,7 @@ pypiserver - minimal PyPI server for use with pip/easy_install
 |pypi-ver| |travis-status| |dependencies| |python-ver| |proj-license|
 
 :Version:     1.3.0
-:Date:        2019-01-31
+:Date:        2019-05-05
 :Source:      https://github.com/pypiserver/pypiserver
 :PyPI:        https://pypi.org/project/pypiserver/
 :Travis:      https://travis-ci.org/pypiserver/pypiserver

--- a/README.rst
+++ b/README.rst
@@ -772,10 +772,10 @@ automatic HTTP redirection, using `nginx`::
       }
     }
 
-Please see [nginx's HTTPS docs for more details](http://nginx.org/en/docs/http/configuring_https_servers.html).
+Please see `nginx's HTTPS docs for more details <http://nginx.org/en/docs/http/configuring_https_servers.html>`_.
 
 Getting and keeping your certificates up-to-date can be simplified using,
-for example, using [certbot and letsencrypt](https://www.digitalocean.com/community/tutorials/how-to-secure-nginx-with-let-s-encrypt-on-ubuntu-18-04).
+for example, using `certbot and letsencrypt <https://www.digitalocean.com/community/tutorials/how-to-secure-nginx-with-let-s-encrypt-on-ubuntu-18-04>`_.
 
 
 Utilizing the API

--- a/README.rst
+++ b/README.rst
@@ -9,7 +9,7 @@ pypiserver - minimal PyPI server for use with pip/easy_install
 ==============================================================================
 |pypi-ver| |travis-status| |dependencies| |python-ver| |proj-license|
 
-:Version:     1.2.7
+:Version:     1.3.0
 :Date:        2019-01-31
 :Source:      https://github.com/pypiserver/pypiserver
 :PyPI:        https://pypi.org/project/pypiserver/

--- a/README.rst
+++ b/README.rst
@@ -476,20 +476,30 @@ installation, by specifying the ``cache`` extras option::
 
     pip install pypiserver[cache]
 
-If you are using a static webserver such as *Apache* or *nginx* as
-a reverse-proxy for pypiserver, additional speedup can be gained by
-directly serving the packages directory:
+Additional speedups can be obtained by using your webserver's builtin
+caching functionality. For example, if you are using `nginx` as a
+reverse-proxy as described below in `Behind a reverse proxy`_, you can
+easily enable caching. For example, to allow nginx to cache up to
+10 gigabytes of data for up to 1 hour::
 
-For instance, in *nginx* you may adding the following config to serve
-packages-directly directly (take care not to expose "sensitive" files)::
+    proxy_cache_path /data/nginx/cache
+                     levels=1:2
+                     keys_zone=pypiserver_cache:10m
+                     max_size=10g
+                     inactive=60m
+                     use_temp_path=off;
 
-    location /packages/ {
-      root /path/to/packages/parentdir;
+    server {
+        # ...
+        location / {
+            proxy_cache pypiserver_cache;
+            proxy_pass http://localhost:8080;
+        }
     }
 
-If you have packages that are very large, you may find it helpful to
-disable hashing of files (set ``--hash-algo=off``, or ``hash_algo=None`` when
-using wsgi).
+Using webserver caching is especially helpful if you have high request
+volume. Using `nginx` caching, a real-world pypiserver installation was
+able to easily support over 1000 package downloads/min at peak load.
 
 
 Managing Automated Startup
@@ -688,7 +698,7 @@ unstable packages on different paths::
 
 Behind a reverse proxy
 ----------------------
-You can run *pypiserver* behind a reverse proxy aswell.
+You can run *pypiserver* behind a reverse proxy as well.
 
 Nginx
 ~~~~~
@@ -699,7 +709,7 @@ Extend your nginx configuration::
     }
 
     server {
-       server_name         myproxy.example.com;
+      server_name         myproxy.example.com;
 
       location / {
         proxy_set_header  Host $host:$server_port;
@@ -708,6 +718,64 @@ Extend your nginx configuration::
         proxy_pass        http://pypi;
       }
     }
+
+As of pypiserver 1.3, you may also use the `X-Forwarded-Host` header in your
+reverse proxy config to enable changing the base URL. For example if you
+want to host pypiserver under a particular path on your server::
+
+    upstream pypi {
+      server              locahost:8000;
+    }
+
+    server {
+      location /pypi/ {
+          proxy_set_header  X-Forwarded-Host $host:$server_port/pypi;
+          proxy_set_header  X-Forwarded-Proto $scheme;
+          proxy_set_header  X-Forwarded-For $proxy_add_x_forwarded_for;
+          proxy_set_header  X-Real-IP $remote_addr;
+          proxy_pass        http://pypi;
+      }
+    }
+
+
+Supporting HTTPS/SSL
+~~~~~~~~~~~~~~~~~~~~
+
+Using a reverse proxy is the preferred way of getting pypiserver behind
+HTTPS. For example, to put pypiserver behind HTTPs on port 443, with
+automatic HTTP redirection, using `nginx`::
+
+    upstream pypi {
+      server               localhost:8000;
+    }
+
+    server {
+      listen              80 default_server;
+      server_name         _;
+      return              301 https://$host$request_uri;
+    }
+
+    server {
+      listen              443 ssl;
+      server_name         pypiserver.example.com;
+
+      ssl_certificate     /etc/star.example.com.crt;
+      ssl_certificate_key /etc/star.example.com.key;
+      ssl_protocols       TLSv1 TLSv1.1 TLSv1.2;
+      ssl_ciphers         HIGH:!aNULL:!MD5;
+
+      location / {
+        proxy_set_header  Host $host:$server_port;
+        proxy_set_header  X-Forwarded-Proto $scheme;
+        proxy_set_header  X-Real-IP $remote_addr;
+        proxy_pass        http://pypi;
+      }
+    }
+
+Please see [nginx's HTTPS docs for more details](http://nginx.org/en/docs/http/configuring_https_servers.html).
+
+Getting and keeping your certificates up-to-date can be simplified using,
+for example, using [certbot and letsencrypt](https://www.digitalocean.com/community/tutorials/how-to-secure-nginx-with-let-s-encrypt-on-ubuntu-18-04).
 
 
 Utilizing the API
@@ -795,8 +863,6 @@ The following limitations are known:
 - It does not handle misspelled packages as *pypi-repo* does,
   therefore it is suggested to use it with ``--extra-index-url`` instead
   of ``--index-url`` (see `#38 <https://github.com/pypiserver/pypiserver/issues/38>`_).
-- It does not support changing the *prefix* of the path of the url
-  (see `#155 <https://github.com/pypiserver/pypiserver/issues/155>`_ for workarounds).
 
 Please use Github's `bugtracker <https://github.com/pypiserver/pypiserver/issues>`_
 for other bugs you find.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,21 +1,73 @@
 ---
-########################################################################
-# pypiserver docker-compose example
-########################################################################
+# ######################################################################
+# pypiserver docker-compose examples
+# ######################################################################
+# The below examples illustrate different ways that pypiserver may be
+# configured with docker-compose (and by extension, with Docker) to
+# serve your python packages.
+#
+# Most of the configuration options detailed below can be mixed and
+# matched as desired.
+# ######################################################################
 
 version: "3.3"
 
 services:
-    pypiserver:
+
+    # ##################################################################
+    # Default
+    # ##################################################################
+    # The default configuration serves packages from the /data/packages
+    # directory inside the container. This directory is mounted as a
+    # volume in the Dockerfile, so it will be persisted, as long as you
+    # do not remove it with `docker-compose down -v` or
+    # `docker volume rm`.
+    # ##################################################################
+
+    pypiserver-default:
+        image: pypiserver/pypiserver:latest
+        ports:
+            - "8080:8080"
+
+    # ##################################################################
+    # Authenticated
+    # ##################################################################
+    # This config uses a locally created .htpasswd file to authenticate
+    # access to pypiserver. We assume our .htpasswd file is in a local
+    # directory `./auth`, which we mount to `/data/auth` in the
+    # container, and update the `command` from the Dockerfile to look
+    # for that file for authentication. Note that because we are
+    # overriding the default `command`, which tells pypiserver where to
+    # serve packages from, we need to include that part of the command
+    # in addition to our authentication information.
+    # ##################################################################
+
+    pypiserver-authenticated:
         image: pypiserver/pypiserver:latest
         volumes:
             - type: bind
-              source: ./data
-              target: /data
-        # Use an .htpasswd file to control access, serve packages from
-        # ./data (which will be /data in the container)
-        command: -P /data/.htpasswd -a update,download,list /data/packages
+              source: ./auth
+              target: /data/auth
+        command: -P /data/auth/.htpasswd -a update,download,list /data/packages
         ports:
-            - "80:8080"
-volumes:
-    data:
+            - "8081:8080"
+
+    # ##################################################################
+    # Serve local packages
+    # ##################################################################
+    # This config allows us to manage our package directory locally,
+    # rather than in a volume managed directly by docker. Note that
+    # especially if running from a Mac, this may cause performance
+    # degradations, which can be worked around by using the `consistency`
+    # setting if desired. Here, we mount a local `./packages` directory
+    # to `/data/packages`, overriding the standard volume.
+    # ##################################################################
+
+    pypiserver-local-packages:
+        image: pypiserver/pypiserver:latest
+        volumes:
+            - type: bind
+              source: ./packages
+              target: /data/packages
+        ports:
+            - "8082:8080"

--- a/pypiserver/__init__.py
+++ b/pypiserver/__init__.py
@@ -2,9 +2,9 @@ import os
 import re as _re
 import sys
 
-version = __version__ = "1.2.7"
+version = __version__ = "1.3.0"
 __version_info__ = tuple(_re.split('[.-]', __version__))
-__updated__ = "2019-01-31 18:43:27"
+__updated__ = "2019-05-05 15:49:11"
 
 __title__ = "pypiserver"
 __summary__ = "A minimal PyPI server for use with pip/easy_install."


### PR DESCRIPTION
- ENH: pypiserver now consistently and correctly handles the `X-Forwarded-Host`
  header to allow for alternative base URLs (#248, resolves #155, thanks
  @kujyp for an excellent first-time contribution!)
- DOC: significantly more information added to the `docker-compose.yml`
  example, including recipes for various configuration options (thanks
  @jetheurer for pointing out the errors in the existing docs, #243!)
- DOC: removed outdated suggestion to serve the packages data directly via
  a webserver and replaced with information about setting up nginx
  caching (thanks @RiceKab for bringing the issue to our attention, #232)

Resolves #232 