### PR TITLE
Do not force port 8080 in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -43,5 +43,5 @@ USER pypiserver
 WORKDIR /data
 EXPOSE 8080
 
-ENTRYPOINT ["pypi-server", "-p", "8080"]
+ENTRYPOINT ["pypi-server"]
 CMD ["packages"]


### PR DESCRIPTION
I don't see a reason to force port 8080, I'd rather be able to do `docker run -p 80:8888 pypi --port 8888`

Personally my use case is when using AWS ECS under awsvpc networking mode, the container port is the host port so I need to be able to use `--port 80` to properly run the server.