### PR TITLE
Correct a command-line argument parsing bug

### DIFF
--- a/pypiserver/__main__.py
+++ b/pypiserver/__main__.py
@@ -233,7 +233,7 @@ def main(argv=None):
             c.password_file = v
         elif k in ("-o", "--overwrite"):
             c.overwrite = True
-        elif k in "--hash-algo":
+        elif k == "--hash-algo":
             c.hash_algo = None if not pypiserver.str2bool(v, c.hash_algo) else v
         elif k == "--log-file":
             c.log_file = v


### PR DESCRIPTION
This PR will correct a bug that affects the parsing of the `-h` command-line argument, which is the short version of the `--help` argument to print the help message.

Currently the command-line argument `-h` raises this error:

> $ pypi-server -h
> Error: while trying to list root(C:\Users\maggyero\packages): [WinError 3] Le chemin d’accès spécifié est introuvable: 'C:\\Users\\maggyero\\packages'

This is because the `-h` argument was intercepted by a preceding incorrect `elif` clause:

> elif k in "--hash-algo":  # incorrect, should be: elif k == "--hash-algo:"
> [...]
> elif k in ("-h", "--help"):