### PR TITLE
[268] Ensure remove_pkg removes all pkg instances

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,10 @@ Changelog
 1.3.2 (tbd)
 -----------
 
+- FIX: The `remove_pkg` API action now removes any extant instances of a
+  package name-version combination, not just the first one found. This means
+  that now, for example, if a `.whl` and `.tar.gz` file exist for the
+  requested package name and version, both will be removed.
 - DEV: switched to gitlab for CI
 
 1.3.1 (2019-09-10)

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -7,7 +7,8 @@ Changelog
 - FIX: The `remove_pkg` API action now removes any extant instances of a
   package name-version combination, not just the first one found. This means
   that now, for example, if a `.whl` and `.tar.gz` file exist for the
-  requested package name and version, both will be removed.
+  requested package name and version, both will be removed (thanks to
+  @esciara for reporting in #268)
 - DEV: switched to gitlab for CI
 
 1.3.1 (2019-09-10)

--- a/pypiserver/_app.py
+++ b/pypiserver/_app.py
@@ -147,14 +147,16 @@ def remove_pkg():
     if not name or not version:
         msg = "Missing 'name'/'version' fields: name=%s, version=%s"
         raise HTTPError(400, msg % (name, version))
-    found = None
-    for pkg in core.find_packages(packages()):
-        if pkg.pkgname == name and pkg.version == version:
-            found = pkg
-            break
-    if found is None:
+    pkgs = list(
+        filter(
+            lambda pkg: pkg.pkgname == name and pkg.version == version,
+            core.find_packages(packages()),
+        )
+    )
+    if len(pkgs) == 0:
         raise HTTPError(404, "%s (%s) not found" % (name, version))
-    os.unlink(found.fn)
+    for pkg in pkgs:
+        os.unlink(pkg.fn)
 
 
 Upload = namedtuple("Upload", "pkg sig")


### PR DESCRIPTION
Reported by @esciara in #268.

Previously, the `remove_pkg` command was only removing the first
matching package that it found so if, for example, there were a .tar.gz
file and a .whl file, it would only remove one of them.

Of course, it could be run in succession to accomplish full removal, but
the expected behavior is that removal will remove the package entirely.

Here, I've grouped `remove_pkg` related tests into a test class, added
some tests that verify the expected behavior, and updated the
`remove_pkg` method to remove all matching packages.