### PR TITLE
Update welcome.html

### DIFF
--- a/pypiserver/welcome.html
+++ b/pypiserver/welcome.html
@@ -4,7 +4,7 @@
 
 <p> To use this server with pip, run the the following command:
 <blockquote><pre>
-pip install --extra-index-url {{URL}} PACKAGE [PACKAGE2...]
+pip install --extra-index-url {{URL}}simple/ PACKAGE [PACKAGE2...]
 </pre></blockquote></p>
 
 <p> To use this server with easy_install, run the the following command:


### PR DESCRIPTION
Replace:

```
pip install --extra-index-url http://localhost:8080/ PACKAGE [PACKAGE2...]
```

with (adding the `simple/` path segment to the URI):

```
pip install --extra-index-url http://localhost:8080/simple/ PACKAGE [PACKAGE2...]
```

to avoid HTTP 303 redirections from http://localhost:8080/PACKAGE/ to http://localhost:8080/simple/PACKAGE/ by `pypiserver` when running the command to install PACKAGE.