### PR TITLE
Pull .travis.yml back into repo

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,24 @@
+sudo: required
+language: python
+services: docker
+
+python:
+  - 2.7
+  - 3.4
+  - 3.5
+  - 3.6
+  - pypy
+  - pypy3
+
+install:
+  - pip install -U setuptools twine pip sphinx tox tox-travis
+
+script:
+  - ./bin/test-docker.sh
+  - ./bin/test_standalone.sh
+  - tox
+  - ./bin/check_readme.sh
+
+branches:
+  except:
+    - standalone


### PR DESCRIPTION
I didn't realize GitLab does not support running PRs on forks for
mirrored GitHub repos. I have switched other projects to Azure
pipelines, but just to get things going, I'm going to pull .travis.yml
back in here.