### PR TITLE
Update welcome.html

### DIFF
--- a/pypiserver/welcome.html
+++ b/pypiserver/welcome.html
@@ -4,12 +4,12 @@
 
 <p> To use this server with pip, run the the following command:
 <blockquote><pre>
-pip install --extra-index-url {{URL}}simple/ PACKAGE [PACKAGE2...]
+pip install --index-url {{URL}}simple/ PACKAGE [PACKAGE2...]
 </pre></blockquote></p>
 
 <p> To use this server with easy_install, run the the following command:
 <blockquote><pre>
-easy_install -i {{URL}}simple/ PACKAGE
+easy_install --index-url {{URL}}simple/ PACKAGE [PACKAGE2...]
 </pre></blockquote></p>
 
 <p>The complete list of all packages can be found <a href="{{PACKAGES}}">here</a>

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -126,7 +126,7 @@ def test_root_count(root, testapp):
 
 def test_root_hostname(testapp):
     resp = testapp.get("/", headers={"Host": "systemexit.de"})
-    resp.mustcontain("easy_install -i http://systemexit.de/simple/ PACKAGE")
+    resp.mustcontain("easy_install --index-url http://systemexit.de/simple/ PACKAGE")
     # go("http://systemexit.de/")
 
 
@@ -307,18 +307,18 @@ def test_simple_index_case(root, testapp):
 
 def test_nonroot_root(testpriv):
     resp = testpriv.get("/priv/", headers={"Host": "nonroot"})
-    resp.mustcontain("easy_install -i http://nonroot/priv/simple/ PACKAGE")
+    resp.mustcontain("easy_install --index-url http://nonroot/priv/simple/ PACKAGE")
 
 
 def test_nonroot_root_with_x_forwarded_host(testapp):
     resp = testapp.get("/", headers={"X-Forwarded-Host": "forward.ed/priv/"})
-    resp.mustcontain("easy_install -i http://forward.ed/priv/simple/ PACKAGE")
+    resp.mustcontain("easy_install --index-url http://forward.ed/priv/simple/ PACKAGE")
     resp.mustcontain("""<a href="/priv/packages/">here</a>""")
 
 
 def test_nonroot_root_with_x_forwarded_host_without_trailing_slash(testapp):
     resp = testapp.get("/", headers={"X-Forwarded-Host": "forward.ed/priv"})
-    resp.mustcontain("easy_install -i http://forward.ed/priv/simple/ PACKAGE")
+    resp.mustcontain("easy_install --index-url http://forward.ed/priv/simple/ PACKAGE")
     resp.mustcontain("""<a href="/priv/packages/">here</a>""")
 
 


### PR DESCRIPTION
This PR will:

* replace the `--extra-index-url` option with `index-url` for the `pip install` command, since `pypi-server` redirects to PyPI anyway when needed;
* replace the short form `-i` option with the full form `--index-url` for the `easy_install` command, to be explicit and consistent with the `pip install` command;
* add a list of package arguments to the `easy_install` command to be consistent with the `pip install` command.