### PR TITLE
Use python 3.6 for the Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.6-alpine as base
+FROM python:3.6-alpine3.10 as base
 
 # Copy the requirements & code and install them
 # Do this in a separate image in a separate directory

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,48 +1,33 @@
-FROM alpine:3.8 AS base
+FROM python:3.6-alpine as base
 
-# Install python and modules that can't be installed via pip
-# Delete the uncompiled variants to shave off ~10MB of the docker file
+# Copy the requirements & code and install them
+# Do this in a separate image in a separate directory
+# to not have all the build stuff in the final image
+FROM base AS builder
+RUN apk update
+# Needed to build cffi
+RUN apk add python-dev build-base libffi-dev
+COPY . /code
+RUN mkdir /install
+RUN pip install --no-warn-script-location \
+                --prefix=/install \
+                /code --requirement /code/docker-requirements.txt
+
+FROM base
+
 RUN addgroup -S -g 9898 pypiserver \
     && adduser -S -u 9898 -G pypiserver pypiserver \
     && mkdir -p /data/packages \
     && chown -R pypiserver:pypiserver /data/packages \
     # Set the setgid bit so anything added here gets associated with the
     # pypiserver group
-    && chmod g+s /data/packages \
-    && apk --no-cache add python py2-bcrypt py2-cffi py2-six \
-    && find /usr -name "*.py" ! -name "__*" -exec rm {} \; \
-    # Ensure pip is available to all further images
-    && apk add --no-cache py2-pip
-
-FROM base as builder
-
-# Copy the requirements and install them
-# Do this in a separate image in a separate directory
-# to not have all the pip stuff in the final image
-COPY docker-requirements.txt /requirements.txt
-
-# Install python packages
-RUN mkdir /install \
-    && pip install --prefix=/install --requirement /requirements.txt \
-    && find /install -name "*.py" ! -name "__*" -exec rm {} \;
-
-FROM base
+    && chmod g+s /data/packages
 
 # Copy the libraries installed via pip
-COPY --from=builder /install /usr
-
-COPY . /code
-
-RUN apk add py2-setuptools \
-    && cd code \
-    && python setup.py install \
-    && cd / \
-    && rm -rf code
-
-VOLUME /data/packages
+COPY --from=builder /install /usr/local
 USER pypiserver
+VOLUME /data/packages
 WORKDIR /data
 EXPOSE 8080
-
 ENTRYPOINT ["pypi-server", "-p", "8080"]
 CMD ["packages"]

--- a/docker-requirements.txt
+++ b/docker-requirements.txt
@@ -1,1 +1,2 @@
 passlib==1.7.1
+bcrypt==3.1.7


### PR DESCRIPTION
Closes #281

The resulting image should work the same way as the previous Python 2 based one.

I based the Docker image on `python:3.6-alpine` because I believe it is cleaner to use the official Python image for dockerized Python apps, however it comes at the cost of a larger image (~100M). Tell me if it's a problem and I'll find a fix.

I do not think it is possible to be as small as the Python 2 based image though, because Python seems to get slightly bigger at each release.

Using 3.7 or even 3.8 instead is just a matter of replacing the `FROM` statement, but I do not know if you support them yet so I played it safe.

Hope you will find this PR useful !