### PR TITLE
FIX: requirements for docker tests in gitlab

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -22,7 +22,7 @@ test-docker:
   except:
     - standalone
   before_script:
-    - apk add --no-cache curl python3
+    - apk add --no-cache curl python3 python3-dev gcc libffi-dev musl-dev openssl-dev
     - pip3 install twine
   script:
     - ./bin/test-docker.sh


### PR DESCRIPTION
The gitlab tests started failing with GL's newest "docker in docker"
image due to the lack of some core C library headers. This ensures that
everything needed for twine (i.e. cryptography) is present before doing
a pip install for twine.