### PR TITLE
Fix CherryPyWSGIServer import

### DIFF
--- a/pypiserver/bottle.py
+++ b/pypiserver/bottle.py
@@ -2792,7 +2792,10 @@ class WSGIRefServer(ServerAdapter):
 
 class CherryPyServer(ServerAdapter):
     def run(self, handler): # pragma: no cover
-        from cherrypy import wsgiserver
+        try:
+            from cheroot.wsgi import Server as CherryPyWSGIServer
+        except ImportError:
+            from cherrypy.wsgiserver import CherryPyWSGIServer
         self.options['bind_addr'] = (self.host, self.port)
         self.options['wsgi_app'] = handler
 
@@ -2803,7 +2806,7 @@ class CherryPyServer(ServerAdapter):
         if keyfile:
             del self.options['keyfile']
 
-        server = wsgiserver.CherryPyWSGIServer(**self.options)
+        server = CherryPyWSGIServer(**self.options)
         if certfile:
             server.ssl_certificate = certfile
         if keyfile:


### PR DESCRIPTION
CherryPy changed the import location in recent versions.
This attempts the new or falls back to the old location.