### PR TITLE
Include watchdog for cache in Docker image

### DIFF
--- a/docker-requirements.txt
+++ b/docker-requirements.txt
@@ -1,2 +1,3 @@
 passlib==1.7.2
 bcrypt==3.1.7
+watchdog==0.10.3


### PR DESCRIPTION
Include watchdog as a dependency in the docker image pip requirements.
This is very useful in situations where your packages are mounted over
the network which may be a typical use case for the image.

As passlib is included as a default dependency this seems like a natural
addition.

---

Have built an image with this configuration which I'm using in Azure with
Azure's File Shares and it lead to a huge performance improvement on
even quite a small (< 100) number of packages.