### PR TITLE
Update Dockerfile. Update docker base images.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,33 +1,64 @@
-FROM python:3.6-alpine3.10 as base
+FROM python:3.8-alpine3.12 as base
 
 # Copy the requirements & code and install them
 # Do this in a separate image in a separate directory
 # to not have all the build stuff in the final image
-FROM base AS builder
-RUN apk update
-# Needed to build cffi
-RUN apk add python-dev build-base libffi-dev
+FROM base AS builder_gosu
+
+ENV GOSU_VERSION 1.12
+
+RUN apk add --no-cache --virtual .build-deps \
+        ca-certificates \
+        dpkg \
+        gnupg \
+    && dpkgArch="$(dpkg --print-architecture | awk -F- '{ print $NF }')" \
+    && wget -O /usr/local/bin/gosu https://github.com/tianon/gosu/releases/download/${GOSU_VERSION}/gosu-${dpkgArch} \
+    && wget -O /usr/local/bin/gosu.asc https://github.com/tianon/gosu/releases/download/${GOSU_VERSION}/gosu-${dpkgArch}.asc \
+    # verify the signature
+    && export GNUPGHOME="$(mktemp -d)" \
+    && gpg --batch --keyserver hkps://keys.openpgp.org --recv-keys B42F6819007F00F88E364FD4036A9C25BF357DD4 \
+    && gpg --batch --verify /usr/local/bin/gosu.asc /usr/local/bin/gosu \
+    && command -v gpgconf && gpgconf --kill all || true \
+    && rm -rf "$GNUPGHOME" /usr/local/bin/gosu.asc \
+    && chmod +x /usr/local/bin/gosu \
+    # check installation
+    && gosu --version \
+    && gosu nobody true \
+    && apk del --no-cache \
+        .build-deps \
+    && rm -rf /var/cache/apk/* \
+    && rm -rf /tmp/*
+
+FROM base AS builder_dependencies
+
 COPY . /code
-RUN mkdir /install
-RUN pip install --no-warn-script-location \
+
+RUN apk add --no-cache --virtual .build-deps \
+        build-base \
+        libffi-dev \
+    && mkdir /install \
+    && python -m pip install --no-warn-script-location \
                 --prefix=/install \
-                /code --requirement /code/docker-requirements.txt
+                /code --requirement /code/docker-requirements.txt \
+    && apk del --no-cache \
+        .build-deps \
+    && rm -rf /var/cache/apk/* \
+    && rm -rf /tmp/*
 
 FROM base
+# Copy the libraries installed via pip
+COPY --from=builder_dependencies /install /usr/local
+COPY --from=builder_gosu /usr/local/bin/gosu /usr/local/bin/gosu
+COPY entrypoint.sh /entrypoint.sh
 
 RUN addgroup -S -g 9898 pypiserver \
     && adduser -S -u 9898 -G pypiserver pypiserver \
     && mkdir -p /data/packages \
-    && chown -R pypiserver:pypiserver /data/packages \
-    # Set the setgid bit so anything added here gets associated with the
-    # pypiserver group
-    && chmod g+s /data/packages
+    && chmod +x /entrypoint.sh
 
-# Copy the libraries installed via pip
-COPY --from=builder /install /usr/local
-USER pypiserver
 VOLUME /data/packages
 WORKDIR /data
-EXPOSE 8080
-ENTRYPOINT ["pypi-server", "-p", "8080"]
-CMD ["packages"]
+ENV PORT=8080
+EXPOSE $PORT
+
+ENTRYPOINT ["/entrypoint.sh"]

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,0 +1,15 @@
+#!/bin/ash
+
+set -euo pipefail
+
+chown -R pypiserver:pypiserver /data
+
+if [ "$@" = "" ]; then
+    # default CMD
+    echo "Set default option '/data/packages'"
+    set -- " /data/packages"
+else
+    # 
+    echo "Using custom CMD: $@"
+fi
+exec gosu pypiserver pypi-server -p "$PORT" $@


### PR DESCRIPTION
This PR udpates the Dockerfile.

Docker base images are updated.

The main change is the introduction of an `entrypoint` script, which sets the permission on the package directry `/data/packages`.

In the previous version of the `Dockerfile` this was done before declaring the same directory as docker `VOLUME`, which switched ownership back to `root`.

This behaviour caused: https://github.com/pypiserver/pypiserver/issues/309

To still run `pypiserver` as user and not `root`, the tool `su-exec` was introduced and used within `entrypoint.sh`.