### PR TITLE
Restore ability to drop hashing in new config

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -9,7 +9,7 @@ pypiserver - minimal PyPI server for use with pip/easy_install
 ==============================================================================
 |pypi-ver| |travis-status| |dependencies| |python-ver| |proj-license|
 
-:Version:     1.4.2
+:Version:     2.0.0dev1
 :Date:        2020-10-10
 :Source:      https://github.com/pypiserver/pypiserver
 :PyPI:        https://pypi.org/project/pypiserver/

--- a/pypiserver/__init__.py
+++ b/pypiserver/__init__.py
@@ -2,9 +2,9 @@ import os
 import re as _re
 import sys
 
-version = __version__ = "1.4.2"
+version = __version__ = "2.0.0dev1"
 __version_info__ = tuple(_re.split("[.-]", __version__))
-__updated__ = "2020-10-10 08:15:56"
+__updated__ = "2020-10-11 11:23:15"
 
 __title__ = "pypiserver"
 __summary__ = "A minimal PyPI server for use with pip/easy_install."


### PR DESCRIPTION
Thanks @elfjes for pointing out that I'd missed this! I also went ahead
and bumped the version in the README to 2.0.0dev1, so that it's clear
that what's in master shouldn't be what people expect from pypi or in the
docker image.