### PR TITLE
Use argparse config throughout app

### DIFF
--- a/pypiserver/__init__.py
+++ b/pypiserver/__init__.py
@@ -181,13 +181,3 @@ def paste_app_factory(_global_config, **local_conf):
     updated_conf = backwards_compat_kwargs(mapped_conf)
 
     return app(**updated_conf)
-
-
-def _logwrite(logger, level, msg):
-    if msg:
-        line_endings = ["\r\n", "\n\r", "\n"]
-        for le in line_endings:
-            if msg.endswith(le):
-                msg = msg[: -len(le)]
-        if msg:
-            logger.log(level, msg)

--- a/pypiserver/__init__.py
+++ b/pypiserver/__init__.py
@@ -135,8 +135,6 @@ def app_from_config(config: RunConfig) -> Bottle:
     # modules map, so that any future imports do not receive our mutated version
     sys.modules.pop("pypiserver._app", None)
     _app.config = config
-    _app.iter_packages = config.iter_packages
-    _app.package_root = config.package_root
     # Add a reference to our config on the Bottle app for easy access in testing
     # and other contexts.
     _app.app._pypiserver_config = config

--- a/pypiserver/__init__.py
+++ b/pypiserver/__init__.py
@@ -99,7 +99,7 @@ def app(**kwargs: t.Any) -> Bottle:
     :param kwds: Any overrides for defaults. Any property of RunConfig
         (or its base), defined in `pypiserver.config`, may be overridden.
     """
-    config = Config.default_with_updates(**backwards_compat_kwargs(kwargs))
+    config = Config.default_with_overrides(**backwards_compat_kwargs(kwargs))
     return app_from_config(config)
 
 

--- a/pypiserver/__main__.py
+++ b/pypiserver/__main__.py
@@ -3,14 +3,13 @@
 
 from __future__ import print_function
 
-import getopt
 import logging
 import os
-import re
 import sys
-import textwrap
+import typing as t
 
 import functools as ft
+from pypiserver.config import Config, UpdateConfig
 
 
 log = logging.getLogger("pypiserver.main")
@@ -20,10 +19,11 @@ def init_logging(
     level=logging.NOTSET,
     frmt=None,
     filename=None,
-    stream=sys.stderr,
+    stream: t.IO = None,
     logger=None,
 ):
     logger = logger or logging.getLogger()
+    stream = stream or sys.stderr
     logger.setLevel(level)
 
     formatter = logging.Formatter(frmt)
@@ -38,275 +38,16 @@ def init_logging(
         logger.addHandler(handler)
 
 
-def usage():
-    return textwrap.dedent(
-        """\
-  pypi-server [OPTIONS] [PACKAGES_DIRECTORY...]
-    start PyPI compatible package server serving packages from
-    PACKAGES_DIRECTORY. If PACKAGES_DIRECTORY is not given on the
-    command line, it uses the default ~/packages.  pypiserver scans this
-    directory recursively for packages. It skips packages and
-    directories starting with a dot. Multiple package directories can be
-    specified.
-
-  pypi-server understands the following options:
-
-    -p, --port PORT
-      Listen on port PORT (default: 8080).
-
-    -i, --interface INTERFACE
-      Listen on interface INTERFACE (default: 0.0.0.0, any interface).
-
-    -a, --authenticate (update|download|list), ...
-      Comma-separated list of (case-insensitive) actions to authenticate.
-      Requires to have set the password (-P option).
-      To password-protect package downloads (in addition to uploads) while
-      leaving listings public, use:
-        -P foo/htpasswd.txt -a update,download
-      To allow unauthorized access, use:
-        -P . -a .
-      Note that when uploads are not protected, the `register` command
-      is not necessary, but `~/.pypirc` still need username and password fields,
-      even if bogus.
-      By default, only 'update' is password-protected.
-
-    -P, --passwords PASSWORD_FILE
-      Use apache htpasswd file PASSWORD_FILE to set usernames & passwords when
-      authenticating certain actions (see -a option).
-      To allow unauthorized access, use:
-        -P . -a .
-
-    --disable-fallback
-      Disable redirect to real PyPI index for packages not found in the
-      local index.
-
-    --fallback-url FALLBACK_URL
-      For packages not found in the local index, this URL will be used to
-      redirect to (default: https://pypi.org/simple/).
-
-    --server METHOD
-      Use METHOD to run the server. Valid values include paste,
-      cherrypy, twisted, gunicorn, gevent, wsgiref, auto. The
-      default is to use "auto" which chooses one of paste, cherrypy,
-      twisted or wsgiref.
-
-    -r, --root PACKAGES_DIRECTORY
-      [deprecated] Serve packages from PACKAGES_DIRECTORY.
-
-    -o, --overwrite
-      Allow overwriting existing package files.
-
-    --hash-algo ALGO
-      Any `hashlib` available algo used as fragments on package links.
-      Set one of (0, no, off, false) to disabled it (default: md5).
-
-    --welcome HTML_FILE
-      Uses the ASCII contents of HTML_FILE as welcome message response.
-
-    -v
-      Enable verbose logging; repeat for more verbosity.
-
-    --log-file FILE
-      Write logging info into this FILE, as well as to stdout or stderr, if configured.
-
-    --log-stream STREAM
-      Log messages to the specified STREAM. Valid values are "stdout", "stderr", or "none"
-
-    --log-frmt FORMAT
-      The logging format-string.  (see `logging.LogRecord` class from standard python library)
-      [Default: %(asctime)s|%(name)s|%(levelname)s|%(thread)d|%(message)s]
-
-    --log-req-frmt FORMAT
-      A format-string selecting Http-Request properties to log; set to  '%s' to see them all.
-      [Default: %(bottle.request)s]
-
-    --log-res-frmt FORMAT
-      A format-string selecting Http-Response properties to log; set to  '%s' to see them all.
-      [Default: %(status)s]
-
-    --log-err-frmt FORMAT
-      A format-string selecting Http-Error properties to log; set to  '%s' to see them all.
-      [Default: %(body)s: %(exception)s \n%(traceback)s]
-
-    --cache-control AGE
-      Add "Cache-Control: max-age=AGE, public" header to package downloads.
-      Pip 6+ needs this for caching.
-
-
-  pypi-server -h, --help
-    Show this help message.
-
-  pypi-server --version
-    Show pypi-server's version.
-
-  pypi-server -U [OPTIONS] [PACKAGES_DIRECTORY...]
-    Update packages in PACKAGES_DIRECTORY. This command searches
-    pypi.org for updates and shows a pip command line which
-    updates the package.
-
-  The following additional options can be specified with -U:
-
-    -x
-      Execute the pip commands instead of only showing them.
-
-    -d DOWNLOAD_DIRECTORY
-      Download package updates to this directory. The default is to use
-      the directory which contains the latest version of the package to
-      be updated.
-
-    -u
-      Allow updating to unstable version (alpha, beta, rc, dev versions).
-      
-    --blacklist-file BLACKLIST_FILE
-      Don't update packages listed in this file (one package name per line,
-      without versions, '#' comments honored). This can be useful if you upload
-      private packages into pypiserver, but also keep a mirror of public
-      packages that you regularly update. Attempting to pull an update of
-      a private package from `pypi.org` might pose a security risk - e.g. a
-      malicious user might publish a higher version of the private package,
-      containing arbitrary code.
-
-  Visit https://pypi.org/project/pypiserver/ for more information.
-  """
-    )
-
-
 def main(argv=None):
     import pypiserver
 
     if argv is None:
         argv = sys.argv
 
-    command = "serve"
+    config = Config.from_args(argv)
 
-    c = pypiserver.Configuration(**pypiserver.default_config())
-
-    update_dry_run = True
-    update_directory = None
-    update_stable_only = True
-    update_blacklist_file = None
-
-    try:
-        opts, roots = getopt.getopt(
-            argv[1:],
-            "i:p:a:r:d:P:Uuvxoh",
-            [
-                "interface=",
-                "passwords=",
-                "authenticate=",
-                "port=",
-                "root=",
-                "server=",
-                "fallback-url=",
-                "disable-fallback",
-                "overwrite",
-                "hash-algo=",
-                "blacklist-file=",
-                "log-file=",
-                "log-stream=",
-                "log-frmt=",
-                "log-req-frmt=",
-                "log-res-frmt=",
-                "log-err-frmt=",
-                "welcome=",
-                "cache-control=",
-                "version",
-                "help",
-            ],
-        )
-    except getopt.GetoptError:
-        err = sys.exc_info()[1]
-        sys.exit(f"usage error: {err}")
-
-    for k, v in opts:
-        if k in ("-p", "--port"):
-            try:
-                c.port = int(v)
-            except Exception:
-                err = sys.exc_info()[1]
-                sys.exit(f"Invalid port({v!r}) due to: {err}")
-        elif k in ("-a", "--authenticate"):
-            c.authenticated = [
-                a.lower() for a in re.split("[, ]+", v.strip(" ,")) if a
-            ]
-            if c.authenticated == ["."]:
-                c.authenticated = []
-            else:
-                actions = ("list", "download", "update")
-                for a in c.authenticated:
-                    if a not in actions:
-                        errmsg = (
-                            f"Action '{a}' for option `{k}`"
-                            f" not one of {actions}!"
-                        )
-                        sys.exit(errmsg)
-        elif k in ("-i", "--interface"):
-            c.host = v
-        elif k in ("-r", "--root"):
-            roots.append(v)
-        elif k == "--disable-fallback":
-            c.redirect_to_fallback = False
-        elif k == "--fallback-url":
-            c.fallback_url = v
-        elif k == "--server":
-            c.server = v
-        elif k == "--welcome":
-            c.welcome_file = v
-        elif k == "--version":
-            print(f"pypiserver {pypiserver.__version__}\n")
-            return
-        elif k == "-U":
-            command = "update"
-        elif k == "-x":
-            update_dry_run = False
-        elif k == "-u":
-            update_stable_only = False
-        elif k == "-d":
-            update_directory = v
-        elif k == "--blacklist-file":
-            update_blacklist_file = v
-        elif k in ("-P", "--passwords"):
-            c.password_file = v
-        elif k in ("-o", "--overwrite"):
-            c.overwrite = True
-        elif k == "--hash-algo":
-            c.hash_algo = None if not pypiserver.str2bool(v, c.hash_algo) else v
-        elif k == "--log-file":
-            c.log_file = v
-        elif k == "--log-stream":
-            c.log_stream = v
-        elif k == "--log-frmt":
-            c.log_frmt = v
-        elif k == "--log-req-frmt":
-            c.log_req_frmt = v
-        elif k == "--log-res-frmt":
-            c.log_res_frmt = v
-        elif k == "--log-err-frmt":
-            c.log_err_frmt = v
-        elif k == "--cache-control":
-            c.cache_control = v
-        elif k == "-v":
-            c.verbosity += 1
-        elif k in ("-h", "--help"):
-            print(usage())
-            sys.exit(0)
-
-    if (
-        not c.authenticated
-        and c.password_file != "."
-        or c.authenticated
-        and c.password_file == "."
-    ):
-        sys.exit(
-            "When auth-ops-list is empty (-a=.), password-file"
-            f" (-P={c.password_file!r}) must also be empty ('.')!"
-        )
-
-    if len(roots) == 0:
-        roots.append(os.path.expanduser("~/packages"))
-
-    roots = [os.path.abspath(x) for x in roots]
-    c.root = roots
+    # roots = [os.path.abspath(x) for x in roots]
+    # c.root = roots
 
     verbose_levels = [
         logging.WARNING,
@@ -314,10 +55,10 @@ def main(argv=None):
         logging.DEBUG,
         logging.NOTSET,
     ]
-    log_level = list(zip(verbose_levels, range(c.verbosity)))[-1][0]
+    log_level = list(zip(verbose_levels, range(config.verbosity)))[-1][0]
 
     valid_streams = {"none": None, "stderr": sys.stderr, "stdout": sys.stdout}
-    if c.log_stream not in valid_streams:
+    if config.log_stream not in valid_streams:
         sys.exit(
             f"Invalid log stream {c.log_stream}."
             f" Choose one of {', '.join(valid_streams.keys())}"
@@ -325,45 +66,50 @@ def main(argv=None):
 
     init_logging(
         level=log_level,
-        filename=c.log_file,
-        frmt=c.log_frmt,
-        stream=valid_streams[c.log_stream],
+        filename=config.log_file,
+        frmt=config.log_frmt,
+        stream=config.log_stream,
     )
 
-    if command == "update":
+    if isinstance(config, UpdateConfig):
         from pypiserver.manage import update_all_packages
 
         update_all_packages(
-            roots,
-            update_directory,
-            dry_run=update_dry_run,
-            stable_only=update_stable_only,
-            blacklist_file=update_blacklist_file,
+            config.roots,
+            config.download_directory,
+            dry_run=not config.execute,
+            stable_only=config.allow_unstable,
+            blacklist_file=config.ignorelist,
         )
         return
 
     # Fixes #49:
     #    The gevent server adapter needs to patch some
     #    modules BEFORE importing bottle!
-    if c.server and c.server.startswith("gevent"):
+    if config.server_method.startswith("gevent"):
         import gevent.monkey  # @UnresolvedImport
 
         gevent.monkey.patch_all()
 
     from pypiserver import bottle
 
-    if c.server not in bottle.server_names:
+    if config.server_method not in bottle.server_names:
         sys.exit(
             f"Unknown server {c.server}."
             f" Choose one of {', '.join(bottle.server_names.keys())}"
         )
 
-    bottle.debug(c.verbosity > 1)
+    bottle.debug(config.verbosity > 1)
     bottle._stderr = ft.partial(
         pypiserver._logwrite, logging.getLogger(bottle.__name__), logging.INFO
     )
-    app = pypiserver.app(**vars(c))
-    bottle.run(app=app, host=c.host, port=c.port, server=c.server)
+    app = pypiserver.app_from_config(config)
+    bottle.run(
+        app=app,
+        host=config.interface,
+        port=config.port,
+        server=config.server_method,
+    )
 
 
 if __name__ == "__main__":

--- a/pypiserver/__main__.py
+++ b/pypiserver/__main__.py
@@ -81,16 +81,25 @@ def main(argv=None):
 
     bottle.debug(config.verbosity > 1)
     bottle._stderr = ft.partial(
-        pypiserver._logwrite, logging.getLogger(bottle.__name__), logging.INFO
+        _logwrite, logging.getLogger(bottle.__name__), logging.INFO
     )
     app = pypiserver.app_from_config(config)
-    app._pypiserver_config = config
     bottle.run(
         app=app,
         host=config.host,
         port=config.port,
         server=config.server_method,
     )
+
+
+def _logwrite(logger, level, msg):
+    if msg:
+        line_endings = ["\r\n", "\n\r", "\n"]
+        for le in line_endings:
+            if msg.endswith(le):
+                msg = msg[: -len(le)]
+        if msg:
+            logger.log(level, msg)
 
 
 if __name__ == "__main__":

--- a/pypiserver/__main__.py
+++ b/pypiserver/__main__.py
@@ -4,7 +4,6 @@
 from __future__ import print_function
 
 import logging
-import os
 import sys
 import typing as t
 

--- a/pypiserver/_app.py
+++ b/pypiserver/_app.py
@@ -36,7 +36,7 @@ except ImportError:  # PY2
 
 
 log = logging.getLogger(__name__)
-config: RunConfig = None
+config: RunConfig
 
 app = Bottle()
 

--- a/pypiserver/_app.py
+++ b/pypiserver/_app.py
@@ -6,6 +6,7 @@ import re
 import zipfile
 import xml.dom.minidom
 
+from pypiserver.config import RunConfig
 from . import __version__
 from . import core
 from .bottle import (
@@ -35,8 +36,7 @@ except ImportError:  # PY2
 
 
 log = logging.getLogger(__name__)
-packages = None
-config = None
+config: RunConfig = None
 
 app = Bottle()
 
@@ -49,7 +49,7 @@ class auth:
 
     def __call__(self, method):
         def protector(*args, **kwargs):
-            if self.action in config.authenticated:
+            if self.action in config.authenticate:
                 if not request.auth or request.auth[1] is None:
                     raise HTTPError(
                         401, headers={"WWW-Authenticate": 'Basic realm="pypi"'}
@@ -104,8 +104,9 @@ def root():
     fp = request.custom_fullpath
 
     try:
-        numpkgs = len(list(packages()))
-    except:
+        numpkgs = len(list(config.iter_packages()))
+    except Exception as exc:
+        log.error(f"Could not list packages: {exc}")
         numpkgs = 0
 
     # Ensure template() does not consider `msg` as filename!
@@ -150,7 +151,7 @@ def remove_pkg():
     pkgs = list(
         filter(
             lambda pkg: pkg.pkgname == name and pkg.version == version,
-            core.find_packages(packages()),
+            core.find_packages(config.iter_packages()),
         )
     )
     if len(pkgs) == 0:
@@ -186,7 +187,9 @@ def file_upload():
         ):
             raise HTTPError(400, f"Bad filename: {uf.raw_filename}")
 
-        if not config.overwrite and core.exists(packages.root, uf.raw_filename):
+        if not config.overwrite and core.exists(
+            config.package_root, uf.raw_filename
+        ):
             log.warning(
                 f"Cannot upload {uf.raw_filename!r} since it already exists! \n"
                 "  You may start server with `--overwrite` option. "
@@ -197,7 +200,7 @@ def file_upload():
                 "  You may start server with `--overwrite` option.",
             )
 
-        core.store(packages.root, uf.raw_filename, uf.save)
+        core.store(config.package_root, uf.raw_filename, uf.save)
         if request.auth:
             user = request.auth[0]
         else:
@@ -254,7 +257,7 @@ def handle_rpc():
         )
         response = []
         ordering = 0
-        for p in packages():
+        for p in config.iter_packages():
             if p.pkgname.count(value) > 0:
                 # We do not presently have any description/summary, returning
                 # version instead
@@ -275,7 +278,7 @@ def handle_rpc():
 @app.route("/simple/")
 @auth("list")
 def simpleindex():
-    links = sorted(core.get_prefixes(packages()))
+    links = sorted(core.get_prefixes(config.iter_packages()))
     tmpl = """\
     <html>
         <head>
@@ -301,11 +304,11 @@ def simple(prefix=""):
         return redirect("/simple/{0}/".format(normalized), 301)
 
     files = sorted(
-        core.find_packages(packages(), prefix=prefix),
+        core.find_packages(config.iter_packages(), prefix=prefix),
         key=lambda x: (x.parsed_version, x.relfn),
     )
     if not files:
-        if config.redirect_to_fallback:
+        if not config.disable_fallback:
             return redirect(f"{config.fallback_url.rstrip('/')}/{prefix}/")
         return HTTPError(404, f"Not Found ({normalized} does not exist)\n\n")
 
@@ -338,7 +341,7 @@ def simple(prefix=""):
 def list_packages():
     fp = request.custom_fullpath
     files = sorted(
-        core.find_packages(packages()),
+        core.find_packages(config.iter_packages()),
         key=lambda x: (os.path.dirname(x.relfn), x.pkgname, x.parsed_version),
     )
     links = [
@@ -364,7 +367,7 @@ def list_packages():
 @app.route("/packages/:filename#.*#")
 @auth("download")
 def server_static(filename):
-    entries = core.find_packages(packages())
+    entries = core.find_packages(config.iter_packages())
     for x in entries:
         f = x.relfn_unix
         if f == filename:

--- a/pypiserver/config.py
+++ b/pypiserver/config.py
@@ -103,10 +103,6 @@ def auth_arg(arg: str) -> t.List[str]:
 
 def hash_algo_arg(arg: str) -> t.Optional[str]:
     """Parse a hash algorithm from the string."""
-    # The standard hashing algorithms are all made available via fully
-    # lowercase names, along with (sometimes) variously cased versions
-    # as well.
-    arg = arg.lower()
     if arg in hashlib.algorithms_available:
         return arg
     try:

--- a/pypiserver/config.py
+++ b/pypiserver/config.py
@@ -145,7 +145,19 @@ def ignorelist_file_arg(arg: t.Optional[str]) -> t.List[str]:
 
 def package_directory_arg(arg: str) -> pathlib.Path:
     """Convert any package directory argument into its absolute path."""
-    return pathlib.Path(arg).expanduser().resolve()
+    pkg_dir = pathlib.Path(arg).expanduser().resolve()
+    try:
+        # Attempt to grab the first item from the directory. The directory may
+        # be empty, in which case we'll get back None, but if the directory does
+        # not exist or we do not have permission to read it, we can catch th
+        # OSError and exit with a useful message.
+        next(pkg_dir.iterdir(), None)
+    except OSError as exc:
+        raise argparse.ArgumentTypeError(
+            "Error: while trying to access package directory "
+            f"({pkg_dir}): {exc}"
+        )
+    return pkg_dir
 
 
 # We need to capture this at compile time, because we replace sys.stderr

--- a/pypiserver/config.py
+++ b/pypiserver/config.py
@@ -525,12 +525,8 @@ class _ConfigCommon:
             "iter_packages",
             "package_root",
         )
-        # Iterate over files in specified package roots.
-        # self.iter_packages = lambda: itertools.chain.from_iterable(
-        #     r.iterdir() for r in self.roots
-        # )
-        # The first package directory is considered the root.
-        # TODO: does anything use this?
+        # The first package directory is considered the root. This is used
+        # for uploads.
         self.package_root = self.roots[0]
 
     @classmethod

--- a/pypiserver/config.py
+++ b/pypiserver/config.py
@@ -584,7 +584,7 @@ class _ConfigCommon:
         The current config is used as a base. Any properties not specified in
         keyword arguments will remain unchanged.
         """
-        return self.__class__(**{**dict(self), **kwargs})
+        return self.__class__(**{**dict(self), **kwargs})  # type: ignore
 
     def __repr__(self) -> str:
         """A string representation indicating the class and its properties."""
@@ -636,7 +636,7 @@ class RunConfig(_ConfigCommon):
         log_res_frmt: str,
         log_err_frmt: str,
         auther: t.Callable[[str, str], bool] = None,
-        **kwargs,
+        **kwargs: t.Any,
     ) -> None:
         """Construct a RuntimeConfig."""
         super().__init__(**kwargs)
@@ -720,7 +720,7 @@ class RunConfig(_ConfigCommon):
         # authentication function.
         def auther(uname: str, pw: str) -> bool:
             loaded_pw_file.load_if_changed()
-            return loaded_pw_file.check_password(uname, pw)  # type: ignore
+            return loaded_pw_file.check_password(uname, pw)
 
         return auther
 
@@ -734,7 +734,7 @@ class UpdateConfig(_ConfigCommon):
         download_directory: t.Optional[str],
         allow_unstable: bool,
         ignorelist: t.List[str],
-        **kwargs,
+        **kwargs: t.Any,
     ) -> None:
         """Construct an UpdateConfig."""
         super().__init__(**kwargs)
@@ -760,7 +760,7 @@ class Config:
     """Config constructor for building a config from args."""
 
     @classmethod
-    def default_with_updates(cls, **kwargs) -> RunConfig:
+    def default_with_updates(cls, **kwargs: t.Any) -> RunConfig:
         default_config = cls.from_args(["run"])
         assert isinstance(default_config, RunConfig)
         return default_config.with_updates(**kwargs)

--- a/pypiserver/config.py
+++ b/pypiserver/config.py
@@ -566,7 +566,7 @@ class _ConfigCommon:
         """Iterate over packages in root directories."""
         yield from (
             itertools.chain.from_iterable(
-                core._listdir(str(r)) for r in self.roots
+                core.listdir(str(r)) for r in self.roots
             )
         )
 

--- a/pypiserver/config.py
+++ b/pypiserver/config.py
@@ -560,11 +560,9 @@ class _ConfigCommon:
             0: logging.WARNING,
             1: logging.INFO,
             2: logging.DEBUG,
-            3: logging.NOTSET,
         }
         # Return a log-level from warning through not set (log all messages).
-        # If we've specified more than 3 levels of verbosity, just return
-        # not set.
+        # If we've specified 3 or more levels of verbosity, just return not set.
         return levels.get(self.verbosity, logging.NOTSET)
 
     def iter_packages(self) -> t.Iterator[core.PkgFile]:

--- a/pypiserver/config.py
+++ b/pypiserver/config.py
@@ -13,7 +13,7 @@ To add a config option:
   `update_parser` in the `get_parser() function`.
 - Add it to the appropriate Config class, `_ConfigCommon` for global options,
   `RunConfig` for `run` options, and `UpdateConfig` for `update` options.
-  - This requires addit it as an `__init__()` kwarg, setting it as an instance
+  - This requires adding it as an `__init__()` kwarg, setting it as an instance
     attribute in `__init__()`, and ensuring it will be parsed from the argparse
     namespace in the `kwargs_from_namespace()` method
 - Ensure your config option is tested in `tests/test_config.py`.

--- a/pypiserver/config.py
+++ b/pypiserver/config.py
@@ -545,7 +545,7 @@ class _ConfigCommon:
         The current config is used as a base. Any properties not specified in
         keyword arguments will remain unchanged.
         """
-        return self.__class__(**dict(self), **kwargs)
+        return self.__class__(**{**dict(self), **kwargs})
 
     def __repr__(self) -> str:
         """A string representation indicating the class and its properties."""
@@ -571,7 +571,9 @@ class _ConfigCommon:
     def __iter__(self) -> t.Iterator[t.Tuple[str, t.Any]]:
         """Iterate over config (k, v) pairs."""
         yield from (
-            (k, v) for k, v in vars(self).items() if not k.startswith("_")
+            (k, v)
+            for k, v in vars(self).items()
+            if not k.startswith("_") and k not in self._derived_properties
         )
 
 
@@ -581,7 +583,7 @@ class RunConfig(_ConfigCommon):
     def __init__(
         self,
         port: int,
-        interface: str,
+        host: str,
         authenticate: t.List[str],
         password_file: t.Optional[str],
         disable_fallback: bool,
@@ -600,7 +602,7 @@ class RunConfig(_ConfigCommon):
         """Construct a RuntimeConfig."""
         super().__init__(**kwargs)
         self.port = port
-        self.interface = interface
+        self.host = host
         self.authenticate = authenticate
         self.password_file = password_file
         self.disable_fallback = disable_fallback
@@ -626,7 +628,7 @@ class RunConfig(_ConfigCommon):
         return {
             **super(RunConfig, cls).kwargs_from_namespace(namespace),
             "port": namespace.port,
-            "interface": namespace.interface,
+            "host": namespace.interface,
             "authenticate": namespace.authenticate,
             "password_file": namespace.passwords,
             "disable_fallback": namespace.disable_fallback,

--- a/pypiserver/core.py
+++ b/pypiserver/core.py
@@ -18,83 +18,8 @@ except ImportError:  # PY2
 
 import pkg_resources
 
-from pypiserver import Configuration
-
 
 log = logging.getLogger(__name__)
-
-
-def configure(**kwds):
-    """
-    :return: a 2-tuple (Configure, package-list)
-    """
-    c = Configuration(**kwds)
-    log.info(f"+++Pypiserver invoked with: {c}")
-
-    if c.root is None:
-        c.root = os.path.expanduser("~/packages")
-    roots = c.root if isinstance(c.root, (list, tuple)) else [c.root]
-    roots = [os.path.abspath(r) for r in roots]
-    for r in roots:
-        try:
-            os.listdir(r)
-        except OSError:
-            err = sys.exc_info()[1]
-            sys.exit(f"Error: while trying to list root({r}): {err}")
-
-    packages = lambda: itertools.chain(*[listdir(r) for r in roots])
-    packages.root = roots[0]
-
-    if not c.authenticated:
-        c.authenticated = []
-    if not callable(c.auther):
-        if c.password_file and c.password_file != ".":
-            from passlib.apache import HtpasswdFile
-
-            htPsswdFile = HtpasswdFile(c.password_file)
-        else:
-            c.password_file = htPsswdFile = None
-        c.auther = functools.partial(auth_by_htpasswd_file, htPsswdFile)
-
-    # Read welcome-msg from external file or failback to the embedded-msg
-    try:
-        if not c.welcome_file:
-            c.welcome_file = "welcome.html"
-            c.welcome_msg = pkg_resources.resource_string(  # @UndefinedVariable
-                __name__, "welcome.html"
-            ).decode(
-                "utf-8"
-            )  # @UndefinedVariable
-        else:
-            with io.open(c.welcome_file, "r", encoding="utf-8") as fd:
-                c.welcome_msg = fd.read()
-    except Exception:
-        log.warning(
-            f"Could not load welcome-file({c.welcome_file})!", exc_info=True
-        )
-
-    if c.fallback_url is None:
-        c.fallback_url = "https://pypi.org/simple"
-
-    if c.hash_algo:
-        try:
-            halgos = hashlib.algorithms_available
-        except AttributeError:
-            halgos = ["md5", "sha1", "sha224", "sha256", "sha384", "sha512"]
-
-        if c.hash_algo not in halgos:
-            sys.exit(f"Hash-algorithm {c.hash_algo} not one of: {halgos}")
-
-    log.info(f"+++Pypiserver started with: {c}")
-
-    return c, packages
-
-
-def auth_by_htpasswd_file(htPsswdFile, username, password):
-    """The default ``config.auther``."""
-    if htPsswdFile is not None:
-        htPsswdFile.load_if_changed()
-        return htPsswdFile.check_password(username, password)
 
 
 mimetypes.add_type("application/octet-stream", ".egg")
@@ -351,7 +276,7 @@ def _digest_file(fpath, hash_algo):
     From http://stackoverflow.com/a/21565932/548792
     """
     blocksize = 2 ** 16
-    digester = getattr(hashlib, hash_algo)()
+    digester = hashlib.new(hash_algo)
     with open(fpath, "rb") as f:
         for block in iter(lambda: f.read(blocksize), b""):
             digester.update(block)

--- a/pypiserver/core.py
+++ b/pypiserver/core.py
@@ -1,22 +1,13 @@
 #! /usr/bin/env python
 """minimal PyPI like server for use with pip/easy_install"""
 
-import functools
 import hashlib
-import io
-import itertools
 import logging
 import mimetypes
 import os
 import re
-import sys
-
-try:  # PY3
-    from urllib.parse import quote
-except ImportError:  # PY2
-    from urllib import quote
-
-import pkg_resources
+import typing as t
+from urllib.parse import quote
 
 
 log = logging.getLogger(__name__)
@@ -180,7 +171,7 @@ class PkgFile:
         return self._fname_and_hash
 
 
-def _listdir(root):
+def _listdir(root: str) -> t.Iterator[PkgFile]:
     root = os.path.abspath(root)
     for dirpath, dirnames, filenames in os.walk(root):
         dirnames[:] = [x for x in dirnames if is_allowed_path(x)]

--- a/pypiserver/core.py
+++ b/pypiserver/core.py
@@ -171,7 +171,7 @@ class PkgFile:
         return self._fname_and_hash
 
 
-def _listdir(root: str) -> t.Iterator[PkgFile]:
+def _listdir(root: str) -> t.Iterable[PkgFile]:
     root = os.path.abspath(root)
     for dirpath, dirnames, filenames in os.walk(root):
         dirnames[:] = [x for x in dirnames if is_allowed_path(x)]
@@ -253,7 +253,7 @@ def _digest_file(fpath, hash_algo):
 try:
     from .cache import cache_manager
 
-    def listdir(root):
+    def listdir(root: str) -> t.Iterable[PkgFile]:
         # root must be absolute path
         return cache_manager.listdir(root, _listdir)
 

--- a/pypiserver/core.py
+++ b/pypiserver/core.py
@@ -203,30 +203,6 @@ def _listdir(root):
                 )
 
 
-def read_lines(filename):
-    """
-    Read the contents of `filename`, stripping empty lines and '#'-comments.
-    Return a list of strings, containing the lines of the file.
-    """
-    lines = []
-
-    try:
-        with open(filename) as f:
-            lines = [
-                line
-                for line in (ln.strip() for ln in f.readlines())
-                if line and not line.startswith("#")
-            ]
-    except Exception:
-        log.error(
-            f'Failed to read package blacklist file "{filename}". '
-            "Aborting server startup, please fix this."
-        )
-        raise
-
-    return lines
-
-
 def find_packages(pkgs, prefix=""):
     prefix = normalize_pkgname(prefix)
     for x in pkgs:

--- a/pypiserver/manage.py
+++ b/pypiserver/manage.py
@@ -169,18 +169,11 @@ def update(pkgset, destdir=None, dry_run=False, stable_only=True):
 
 
 def update_all_packages(
-    roots, destdir=None, dry_run=False, stable_only=True, blacklist_file=None
+    roots, destdir=None, dry_run=False, stable_only=True, ignorelist=None
 ):
     all_packages = itertools.chain(*[core.listdir(r) for r in roots])
 
-    skip_packages = set()
-    if blacklist_file:
-        skip_packages = set(core.read_lines(blacklist_file))
-        print(
-            'Skipping update of blacklisted packages (listed in "{}"): {}'.format(
-                blacklist_file, ", ".join(sorted(skip_packages))
-            )
-        )
+    skip_packages = set(ignorelist or ())
 
     packages = frozenset(
         [pkg for pkg in all_packages if pkg.pkgname not in skip_packages]

--- a/setup.cfg
+++ b/setup.cfg
@@ -7,6 +7,11 @@ universal=1
 [egg_info]
 tag_build =
 
+[flake8]
+max-line-length = 80
+per-file-ignores =
+    **/__init__.py:F401
+
 [mypy]
 check_untyped_defs = True
 follow_imports = silent

--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,6 @@
 #! /usr/bin/env python3
 
+import re
 from pathlib import Path
 
 from setuptools import setup
@@ -22,8 +23,15 @@ def read_file(rel_path: str):
 
 def get_version():
     locals_ = {}
+    version_line = re.compile(
+        r'^[\w =]*__version__ = "\d+\.\d+\.\d+\.?\w*\d*"$'
+    )
     try:
-        exec(read_file("pypiserver/__init__.py"), locals_)
+        for ln in filter(
+            version_line.match,
+            read_file("pypiserver/__init__.py").splitlines(),
+        ):
+            exec(ln, locals_)
     except (ImportError, RuntimeError):
         pass
     return locals_["__version__"]

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -35,11 +35,6 @@ import tests.test_core as test_core
 __main__.init_logging()
 
 
-@pytest.fixture()
-def _app(app):
-    return app.module
-
-
 @pytest.fixture
 def app(tmpdir):
     from pypiserver import app
@@ -197,14 +192,14 @@ def test_favicon(testapp):
     testapp.get("/favicon.ico", status=404)
 
 
-def test_fallback(root, _app, testapp):
-    assert not _app.config.disable_fallback
+def test_fallback(testapp):
+    assert not testapp.app._pypiserver_config.disable_fallback
     resp = testapp.get("/simple/pypiserver/", status=302)
     assert resp.headers["Location"] == "https://pypi.org/simple/pypiserver/"
 
 
-def test_no_fallback(root, _app, testapp):
-    _app.config.disable_fallback = True
+def test_no_fallback(testapp):
+    testapp.app._pypiserver_config.disable_fallback = True
     testapp.get("/simple/pypiserver/", status=404)
 
 
@@ -418,8 +413,8 @@ def test_simple_index_list_name_with_underscore_no_egg(root, testapp):
     assert hrefs == {"foo-bar/"}
 
 
-def test_no_cache_control_set(root, _app, testapp):
-    assert not _app.config.cache_control
+def test_no_cache_control_set(root, testapp):
+    assert not testapp.app._pypiserver_config.cache_control
     root.join("foo_bar-1.0.tar.gz").write("")
     resp = testapp.get("/packages/foo_bar-1.0.tar.gz")
     assert "Cache-Control" not in resp.headers
@@ -436,13 +431,13 @@ def test_cache_control_set(root):
     assert resp.headers["Cache-Control"] == f"public, max-age={AGE}"
 
 
-def test_upload_noAction(root, testapp):
+def test_upload_noAction(testapp):
     resp = testapp.post("/", expect_errors=1)
     assert resp.status == "400 Bad Request"
     assert "Missing ':action' field!" in unescape(resp.text)
 
 
-def test_upload_badAction(root, testapp):
+def test_upload_badAction(testapp):
     resp = testapp.post("/", params={":action": "BAD"}, expect_errors=1)
     assert resp.status == "400 Bad Request"
     assert "Unsupported ':action' field: BAD" in unescape(resp.text)

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -3,6 +3,7 @@
 # Builtin imports
 import logging
 import os
+import pathlib
 
 
 try:  # python 3
@@ -43,7 +44,7 @@ def _app(app):
 def app(tmpdir):
     from pypiserver import app
 
-    return app(root=tmpdir.strpath, authenticated=[])
+    return app(roots=[pathlib.Path(tmpdir.strpath)], authenticate=[])
 
 
 @pytest.fixture
@@ -193,13 +194,13 @@ def test_favicon(testapp):
 
 
 def test_fallback(root, _app, testapp):
-    assert _app.config.redirect_to_fallback
+    assert not _app.config.disable_fallback
     resp = testapp.get("/simple/pypiserver/", status=302)
     assert resp.headers["Location"] == "https://pypi.org/simple/pypiserver/"
 
 
 def test_no_fallback(root, _app, testapp):
-    _app.config.redirect_to_fallback = False
+    _app.config.disable_fallback = True
     testapp.get("/simple/pypiserver/", status=404)
 
 

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -44,7 +44,11 @@ def _app(app):
 def app(tmpdir):
     from pypiserver import app
 
-    return app(roots=[pathlib.Path(tmpdir.strpath)], authenticate=[])
+    return app(
+        roots=[pathlib.Path(tmpdir.strpath)],
+        authenticate=[],
+        password_file=".",
+    )
 
 
 @pytest.fixture

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -228,21 +228,35 @@ _CONFIG_TEST_PARAMS: t.Tuple[ConfigTestCase, ...] = (
         args=["run"],
         legacy_args=[],
         exp_config_type=RunConfig,
-        exp_config_values={"interface": DEFAULTS.INTERFACE},
+        exp_config_values={"host": DEFAULTS.INTERFACE},
     ),
     ConfigTestCase(
         case="Run: interface specified",
         args=["run", "-i", "1.1.1.1"],
         legacy_args=["-i", "1.1.1.1"],
         exp_config_type=RunConfig,
-        exp_config_values={"interface": "1.1.1.1"},
+        exp_config_values={"host": "1.1.1.1"},
     ),
     ConfigTestCase(
         case="Run: interface specified (long form)",
         args=["run", "--interface", "1.1.1.1"],
         legacy_args=["--interface", "1.1.1.1"],
         exp_config_type=RunConfig,
-        exp_config_values={"interface": "1.1.1.1"},
+        exp_config_values={"host": "1.1.1.1"},
+    ),
+    ConfigTestCase(
+        case="Run: host specified",
+        args=["run", "-H", "1.1.1.1"],
+        legacy_args=["-H", "1.1.1.1"],
+        exp_config_type=RunConfig,
+        exp_config_values={"host": "1.1.1.1"},
+    ),
+    ConfigTestCase(
+        case="Run: host specified (long form)",
+        args=["run", "--host", "1.1.1.1"],
+        legacy_args=["--host", "1.1.1.1"],
+        exp_config_type=RunConfig,
+        exp_config_values={"host": "1.1.1.1"},
     ),
     # authenticate
     ConfigTestCase(

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -108,35 +108,35 @@ _CONFIG_TEST_PARAMS: t.Tuple[ConfigTestCase, ...] = (
     ),
     *generate_subcommand_test_cases(
         case="single package directory specified",
-        extra_args=["foo"],
-        exp_config_values={"roots": [pathlib.Path("foo").resolve()]},
+        extra_args=[str(FILE_DIR)],
+        exp_config_values={"roots": [FILE_DIR]},
     ),
     *generate_subcommand_test_cases(
         case="multiple package directory specified",
-        extra_args=["foo", "bar"],
+        extra_args=[str(FILE_DIR), str(FILE_DIR.parent)],
         exp_config_values={
             "roots": [
-                pathlib.Path("foo").resolve(),
-                pathlib.Path("bar").resolve(),
+                FILE_DIR,
+                FILE_DIR.parent,
             ]
         },
     ),
     ConfigTestCase(
         case="update with package directory (out-of-order legacy order)",
-        args=["update", "foo"],
-        legacy_args=["foo", "-U"],
+        args=["update", str(FILE_DIR)],
+        legacy_args=[str(FILE_DIR), "-U"],
         exp_config_type=UpdateConfig,
-        exp_config_values={"roots": [pathlib.Path("foo").resolve()]},
+        exp_config_values={"roots": [FILE_DIR]},
     ),
     ConfigTestCase(
         case="update with multiple package directories (weird ordering)",
-        args=["update", "foo", "bar"],
-        legacy_args=["foo", "-U", "bar"],
+        args=["update", str(FILE_DIR), str(FILE_DIR.parent)],
+        legacy_args=[str(FILE_DIR), "-U", str(FILE_DIR.parent)],
         exp_config_type=UpdateConfig,
         exp_config_values={
             "roots": [
-                pathlib.Path("foo").resolve(),
-                pathlib.Path("bar").resolve(),
+                FILE_DIR,
+                FILE_DIR.parent,
             ]
         },
     ),

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -10,6 +10,12 @@ import pytest
 
 from pypiserver.config import DEFAULTS, Config, RunConfig, UpdateConfig
 
+FILE_DIR = pathlib.Path(__file__).parent.resolve()
+
+# Username and password stored in the htpasswd.a.a test file.
+HTPASS_TEST_FILE = str(FILE_DIR / "htpasswd.a.a")
+HTPASS_TEST_USER = "a"
+HTPASS_TEST_PASS = "a"
 
 TEST_WELCOME_FILE = str(pathlib.Path(__file__).parent / "sample_msg.html")
 TEST_IGNORELIST_FILE = str(pathlib.Path(__file__).parent / "test-ignorelist")
@@ -26,7 +32,9 @@ class ConfigTestCase(t.NamedTuple):
     exp_config_type: t.Type
     # Expected values in the config. These don't necessarily need to be
     # exclusive. Instead, they should just look at the attributes relevant
-    # to the test case at hand.
+    # to the test case at hand. A special "_test" key, if present, should
+    # map to a function that takes the config as an argument. If this
+    # returns a falsey value, the test will be failed.
     exp_config_values: t.Dict[str, t.Any]
 
 
@@ -101,26 +109,36 @@ _CONFIG_TEST_PARAMS: t.Tuple[ConfigTestCase, ...] = (
     *generate_subcommand_test_cases(
         case="single package directory specified",
         extra_args=["foo"],
-        exp_config_values={"roots": ["foo"]},
+        exp_config_values={"roots": [pathlib.Path("foo").resolve()]},
     ),
     *generate_subcommand_test_cases(
         case="multiple package directory specified",
         extra_args=["foo", "bar"],
-        exp_config_values={"roots": ["foo", "bar"]},
+        exp_config_values={
+            "roots": [
+                pathlib.Path("foo").resolve(),
+                pathlib.Path("bar").resolve(),
+            ]
+        },
     ),
     ConfigTestCase(
         case="update with package directory (out-of-order legacy order)",
         args=["update", "foo"],
         legacy_args=["foo", "-U"],
         exp_config_type=UpdateConfig,
-        exp_config_values={"roots": ["foo"]},
+        exp_config_values={"roots": [pathlib.Path("foo").resolve()]},
     ),
     ConfigTestCase(
         case="update with multiple package directories (weird ordering)",
         args=["update", "foo", "bar"],
         legacy_args=["foo", "-U", "bar"],
         exp_config_type=UpdateConfig,
-        exp_config_values={"roots": ["foo", "bar"]},
+        exp_config_values={
+            "roots": [
+                pathlib.Path("foo").resolve(),
+                pathlib.Path("bar").resolve(),
+            ]
+        },
     ),
     # verbosity
     *(
@@ -250,10 +268,14 @@ _CONFIG_TEST_PARAMS: t.Tuple[ConfigTestCase, ...] = (
     ),
     ConfigTestCase(
         case="Run: authenticate specified with dot",
-        args=["run", "-a", "."],
-        legacy_args=["-a", "."],
+        # both auth and pass must be specified as empty if one of them is empty.
+        args=["run", "-a", ".", "-P", "."],
+        legacy_args=["-a", ".", "-P", "."],
         exp_config_type=RunConfig,
-        exp_config_values={"authenticate": ["."]},
+        exp_config_values={
+            "authenticate": ["."],
+            "_test": lambda conf: bool(conf.auther("foo", "bar")) is True,
+        },
     ),
     # passwords
     ConfigTestCase(
@@ -265,17 +287,42 @@ _CONFIG_TEST_PARAMS: t.Tuple[ConfigTestCase, ...] = (
     ),
     ConfigTestCase(
         "Run: passwords file specified",
-        args=["run", "-P", "foo"],
-        legacy_args=["-P", "foo"],
+        args=["run", "-P", HTPASS_TEST_FILE],
+        legacy_args=["-P", HTPASS_TEST_FILE],
         exp_config_type=RunConfig,
-        exp_config_values={"password_file": "foo"},
+        exp_config_values={
+            "password_file": HTPASS_TEST_FILE,
+            "_test": lambda conf: (
+                bool(conf.auther("foo", "bar")) is False
+                and bool(conf.auther("a", "a")) is True
+            ),
+        },
     ),
     ConfigTestCase(
         "Run: passwords file specified (long-form)",
-        args=["run", "--passwords", "foo"],
-        legacy_args=["--passwords", "foo"],
+        args=["run", "--passwords", HTPASS_TEST_FILE],
+        legacy_args=["--passwords", HTPASS_TEST_FILE],
         exp_config_type=RunConfig,
-        exp_config_values={"password_file": "foo"},
+        exp_config_values={
+            "password_file": HTPASS_TEST_FILE,
+            "_test": (
+                lambda conf: (
+                    bool(conf.auther("foo", "bar")) is False
+                    and conf.auther("a", "a") is True
+                )
+            ),
+        },
+    ),
+    ConfigTestCase(
+        "Run: passwords file empty ('.')",
+        # both auth and pass must be specified as empty if one of them is empty.
+        args=["run", "-P", ".", "-a", "."],
+        legacy_args=["-P", ".", "-a", "."],
+        exp_config_type=RunConfig,
+        exp_config_values={
+            "password_file": ".",
+            "_test": lambda conf: bool(conf.auther("foo", "bar")) is True,
+        },
     ),
     # disable-fallback
     ConfigTestCase(

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -287,7 +287,7 @@ _CONFIG_TEST_PARAMS: t.Tuple[ConfigTestCase, ...] = (
         legacy_args=["-a", ".", "-P", "."],
         exp_config_type=RunConfig,
         exp_config_values={
-            "authenticate": ["."],
+            "authenticate": [],
             "_test": lambda conf: bool(conf.auther("foo", "bar")) is True,
         },
     ),

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -110,25 +110,6 @@ def test_listdir_bad_name(tmpdir):
     assert res == []
 
 
-def test_read_lines(tmpdir):
-    filename = "pkg_blacklist"
-    file_contents = (
-        "# Names of private packages that we don't want to upgrade\n"
-        "\n"
-        "my_private_pkg \n"
-        " \t# This is a comment with starting space and tab\n"
-        " my_other_private_pkg"
-    )
-
-    f = tmpdir.join(filename).ensure()
-    f.write(file_contents)
-
-    assert core.read_lines(f.strpath) == [
-        "my_private_pkg",
-        "my_other_private_pkg",
-    ]
-
-
 hashes = (
     # empty-sha256
     (

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -1,5 +1,5 @@
 """
-Test module for . . .
+Test module for app initialization
 """
 # Standard library imports
 from __future__ import (
@@ -10,8 +10,6 @@ from __future__ import (
 )
 import logging
 import pathlib
-from os.path import abspath, dirname, join, realpath
-from sys import path
 
 # Third party imports
 import pytest
@@ -43,14 +41,8 @@ HTPASS_FILE = TEST_DIR / "htpasswd.a.a"
 )
 def test_paste_app_factory(conf_options):
     """Test the paste_app_factory method"""
-    # monkeypatch.setattr(
-    #     "pypiserver.core.configure", lambda **x: (x, [x.keys()])
-    # )
     pypiserver.paste_app_factory({}, **conf_options)
 
 
 def test_app_factory():
-    # monkeypatch.setattr(
-    #     "pypiserver.core.configure", lambda **x: (x, [x.keys()])
-    # )
     assert pypiserver.app() is not pypiserver.app()

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -9,24 +9,24 @@ from __future__ import (
     unicode_literals,
 )
 import logging
+import pathlib
 from os.path import abspath, dirname, join, realpath
 from sys import path
 
 # Third party imports
 import pytest
 
+
 # Local imports
+import pypiserver
 
 logger = logging.getLogger(__name__)
 
-test_dir = realpath(dirname(__file__))
-src_dir = abspath(join(test_dir, ".."))
-path.append(src_dir)
-print(path)
-
-import pypiserver
+TEST_DIR = pathlib.Path(__file__).parent
+HTPASS_FILE = TEST_DIR / "htpasswd.a.a"
 
 
+# TODO: make these tests meaningful
 @pytest.mark.parametrize(
     "conf_options",
     [
@@ -35,22 +35,22 @@ import pypiserver
         {
             "root": "~/unstable_packages",
             "authenticated": "upload",
-            "passwords": "~/htpasswd",
+            "passwords": str(HTPASS_FILE),
         },
         # Verify that the strip parser works properly.
         {"authenticated": str("upload")},
     ],
 )
-def test_paste_app_factory(conf_options, monkeypatch):
+def test_paste_app_factory(conf_options):
     """Test the paste_app_factory method"""
-    monkeypatch.setattr(
-        "pypiserver.core.configure", lambda **x: (x, [x.keys()])
-    )
+    # monkeypatch.setattr(
+    #     "pypiserver.core.configure", lambda **x: (x, [x.keys()])
+    # )
     pypiserver.paste_app_factory({}, **conf_options)
 
 
-def test_app_factory(monkeypatch):
-    monkeypatch.setattr(
-        "pypiserver.core.configure", lambda **x: (x, [x.keys()])
-    )
+def test_app_factory():
+    # monkeypatch.setattr(
+    #     "pypiserver.core.configure", lambda **x: (x, [x.keys()])
+    # )
     assert pypiserver.app() is not pypiserver.app()

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -2,14 +2,9 @@
 Test module for app initialization
 """
 # Standard library imports
-from __future__ import (
-    absolute_import,
-    division,
-    print_function,
-    unicode_literals,
-)
 import logging
 import pathlib
+import typing as t
 
 # Third party imports
 import pytest
@@ -22,6 +17,7 @@ logger = logging.getLogger(__name__)
 
 TEST_DIR = pathlib.Path(__file__).parent
 HTPASS_FILE = TEST_DIR / "htpasswd.a.a"
+WELCOME_FILE = TEST_DIR / "sample_msg.html"
 
 
 # TODO: make these tests meaningful
@@ -39,10 +35,71 @@ HTPASS_FILE = TEST_DIR / "htpasswd.a.a"
         {"authenticated": str("upload")},
     ],
 )
-def test_paste_app_factory(conf_options):
+def test_paste_app_factory(conf_options: dict) -> None:
     """Test the paste_app_factory method"""
-    pypiserver.paste_app_factory({}, **conf_options)
+    pypiserver.paste_app_factory({}, **conf_options)  # type: ignore
 
 
-def test_app_factory():
+def test_app_factory() -> None:
     assert pypiserver.app() is not pypiserver.app()
+
+
+@pytest.mark.parametrize(
+    "incoming, updated",
+    (
+        (
+            {"authenticated": []},
+            {"authenticate": []},
+        ),
+        (
+            {"passwords": "./foo"},
+            {"password_file": "./foo"},
+        ),
+        (
+            {"root": str(TEST_DIR)},
+            {"roots": [TEST_DIR.expanduser().resolve()]},
+        ),
+        (
+            {"root": [str(TEST_DIR), str(TEST_DIR)]},
+            {
+                "roots": [
+                    TEST_DIR.expanduser().resolve(),
+                    TEST_DIR.expanduser().resolve(),
+                ]
+            },
+        ),
+        (
+            {"redirect_to_fallback": False},
+            {"disable_fallback": True},
+        ),
+        (
+            {"server": "auto"},
+            {"server_method": "auto"},
+        ),
+        (
+            {"welcome_file": str(WELCOME_FILE.resolve())},
+            {"welcome_msg": WELCOME_FILE.read_text()},
+        ),
+    ),
+)
+def test_backwards_compat_kwargs_conversion(
+    incoming: t.Dict[str, t.Any], updated: t.Dict[str, t.Any]
+) -> None:
+    """Test converting legacy kwargs to modern ones."""
+    assert pypiserver.backwards_compat_kwargs(incoming) == updated
+
+
+@pytest.mark.parametrize(
+    "kwargs",
+    (
+        {"redirect_to_fallback": False, "disable_fallback": False},
+        {"disable_fallback": False, "redirect_to_fallback": False},
+    ),
+)
+def test_backwards_compat_kwargs_duplicate_check(
+    kwargs: t.Dict[str, t.Any]
+) -> None:
+    """Duplicate legacy and modern kwargs cause an error."""
+    with pytest.raises(ValueError) as err:
+        pypiserver.backwards_compat_kwargs(kwargs)
+    assert "('redirect_to_fallback', 'disable_fallback')" in str(err.value)

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -186,12 +186,12 @@ def test_init_logging_with_none_stream_doesnt_add_stream_handler(dummy_logger):
 def test_welcome_file(main):
     sample_msg_file = os.path.join(os.path.dirname(__file__), "sample_msg.html")
     main(["--welcome", sample_msg_file])
-    assert "Hello pypiserver tester!" in main.app.module.config.welcome_msg
+    assert "Hello pypiserver tester!" in main.app._pypiserver_config.welcome_msg
 
 
 def test_welcome_file_default(main):
     main([])
-    assert "Welcome to pypiserver!" in main.app.module.config.welcome_msg
+    assert "Welcome to pypiserver!" in main.app._pypiserver_config.welcome_msg
 
 
 def test_password_without_auth_list(main, monkeypatch):
@@ -217,12 +217,12 @@ def test_password_alone(main, monkeypatch):
     monkeypatch.setitem(sys.modules, "passlib", mock.MagicMock())
     monkeypatch.setitem(sys.modules, "passlib.apache", mock.MagicMock())
     main(["-P", str(HTPASS_FILE)])
-    assert main.app.module.config.authenticate == ["update"]
+    assert main.app._pypiserver_config.authenticate == ["update"]
 
 
 def test_dot_password_without_auth_list(main, monkeypatch):
     main(["-P", ".", "-a", "."])
-    assert main.app.module.config.authenticate == []
+    assert main.app._pypiserver_config.authenticate == []
 
 
 def test_blacklist_file(main):

--- a/tests/test_manage.py
+++ b/tests/test_manage.py
@@ -221,23 +221,20 @@ def test_update_all_packages(monkeypatch):
         return roots_mock.get(directory, [])
 
     monkeypatch.setattr(manage.core, "listdir", core_listdir_mock)
-    monkeypatch.setattr(manage.core, "read_lines", Mock(return_value=[]))
     monkeypatch.setattr(manage, "update", Mock(return_value=None))
 
     destdir = None
     dry_run = False
     stable_only = True
-    blacklist_file = None
 
     update_all_packages(
         roots=list(roots_mock.keys()),
         destdir=destdir,
         dry_run=dry_run,
         stable_only=stable_only,
-        blacklist_file=blacklist_file,
+        ignorelist=None,
     )
 
-    manage.core.read_lines.assert_not_called()  # pylint: disable=no-member
     manage.update.assert_called_once_with(  # pylint: disable=no-member
         frozenset([public_pkg_1, public_pkg_2, private_pkg_1, private_pkg_2]),
         destdir,
@@ -246,7 +243,7 @@ def test_update_all_packages(monkeypatch):
     )
 
 
-def test_update_all_packages_with_blacklist(monkeypatch):
+def test_update_all_packages_with_ignorelist(monkeypatch):
     """Test calling update_all_packages()"""
     public_pkg_1 = PkgFile("Flask", "1.0")
     public_pkg_2 = PkgFile("requests", "1.0")
@@ -265,29 +262,20 @@ def test_update_all_packages_with_blacklist(monkeypatch):
         return roots_mock.get(directory, [])
 
     monkeypatch.setattr(manage.core, "listdir", core_listdir_mock)
-    monkeypatch.setattr(
-        manage.core,
-        "read_lines",
-        Mock(return_value=["my_private_pkg", "my_other_private_pkg"]),
-    )
     monkeypatch.setattr(manage, "update", Mock(return_value=None))
 
     destdir = None
     dry_run = False
     stable_only = True
-    blacklist_file = "/root/pkg_blacklist"
 
     update_all_packages(
         roots=list(roots_mock.keys()),
         destdir=destdir,
         dry_run=dry_run,
         stable_only=stable_only,
-        blacklist_file=blacklist_file,
+        ignorelist=["my_private_pkg", "my_other_private_pkg"],
     )
 
     manage.update.assert_called_once_with(  # pylint: disable=no-member
         frozenset([public_pkg_1, public_pkg_2]), destdir, dry_run, stable_only
     )
-    manage.core.read_lines.assert_called_once_with(
-        blacklist_file
-    )  # pylint: disable=no-member

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -59,7 +59,7 @@ def _run_server(packdir, port, authed, other_cli=""):
     """Run a server, optionally with partial auth enabled."""
     pswd_opt_choices = {
         True: "-Ptests/htpasswd.a.a -a update,download",
-        False: "-P . -a .",
+        False: "-P. -a.",
         "partial": "-Ptests/htpasswd.a.a -a update",
     }
     pswd_opts = pswd_opt_choices[authed]

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -59,7 +59,7 @@ def _run_server(packdir, port, authed, other_cli=""):
     """Run a server, optionally with partial auth enabled."""
     pswd_opt_choices = {
         True: "-Ptests/htpasswd.a.a -a update,download",
-        False: "-P. -a.",
+        False: "-P . -a .",
         "partial": "-Ptests/htpasswd.a.a -a update",
     }
     pswd_opts = pswd_opt_choices[authed]

--- a/tox.ini
+++ b/tox.ini
@@ -1,27 +1,26 @@
 [tox]
-envlist = py36,py37,py38,pypy3
+envlist = py36, py37, py38, pypy3
 
 [testenv]
 deps=-r{toxinidir}/requirements/dev.pip
 allowlist_externals=
     /bin/sh
     mypy
-    which
 sitepackages=False
 
-[testenv::py]
+[testenv:py{36,37,38}]
 commands=
     /bin/sh -c "{env:PYPISERVER_SETUP_CMD:true}"
     # individual mypy files for now, until we get the rest
     # of the project typechecking
     mypy pypiserver/config.py
-    pytest --cov=pypiserver []
+    pytest --cov=pypiserver
 
-[testenv::pypy]
+[testenv:pypy3]
 commands=
     /bin/sh -c "{env:PYPISERVER_SETUP_CMD:true}"
     # no mypy in pypy
-    pytest --cov=pypiserver []
+    pytest --cov=pypiserver
 
 
 [pytest]

--- a/tox.ini
+++ b/tox.ini
@@ -14,13 +14,13 @@ commands=
     # individual mypy files for now, until we get the rest
     # of the project typechecking
     mypy pypiserver/config.py
-    pytest --cov=pypiserver
+    pytest --cov=pypiserver {posargs}
 
 [testenv:pypy3]
 commands=
     /bin/sh -c "{env:PYPISERVER_SETUP_CMD:true}"
     # no mypy in pypy
-    pytest --cov=pypiserver
+    pytest --cov=pypiserver {posargs}
 
 
 [pytest]

--- a/tox.ini
+++ b/tox.ini
@@ -13,7 +13,9 @@ commands=
     /bin/sh -c "{env:PYPISERVER_SETUP_CMD:true}"
     # individual mypy files for now, until we get the rest
     # of the project typechecking
-    mypy pypiserver/config.py
+    mypy \
+         pypiserver/config.py \
+         tests/test_init.py
     pytest --cov=pypiserver {posargs}
 
 [testenv:pypy3]


### PR DESCRIPTION
This PR is a pretty substantial refactor of the entrypoints of pypiserver (`__main__` and `__init__`) to use the argparse-based config added in #339.

- Updated `RunConfig` and `UpdateConfig` classes to have exclusive init kwargs, instead of taking an namespace. This turned out to be much easier when working with the library-style app initialization in `__init__`, both for direct instantiation and via paste config
- Added an `iter_packages()` method to the `RunConfig` to iterate over packages specified by the configuration (note @elfjes, I think that replacing this with e.g. a `backend` reference will be a nice way to tie in #348)
- Added a general-purpose method to map legacy keyword arguments to the `app()` and `paste_app_factory()` functions to updated forms
- Refactored the `paste_app_factory()` to not mutate the incoming dictionary
- Removed all argument-parsing and config-related code from `__main__` and `core`
- Moved `_logwrite` from `__init__` to `__main__`, since that was the only place it was being used after the updates to `core`
- Updated `digest_file` to use `hashlib.new(algo)` instead of `getattr(hashlib, algo)`, because the former supports more algorithms
- Updated `setup.py` to, instead of calling `eval()` on the entirety of `__init__`, to instead just evaluate the line that defines the version
- Assigned the config to a `._pypiserver_config` attribute on the `Bottle` instance to reduce hacky test workarounds
- Fixed the tox config, which I broke in #339 