### PR TITLE
Add python 3.9 testing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,7 @@ python:
   - 3.6
   - 3.7
   - 3.8
+  - 3.9-dev
   - pypy3
 
 install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ python:
   - 3.6
   - 3.7
   - 3.8
-  - 3.9-dev
+  - 3.9
   - pypy3
 
 install:

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py36, py37, py38, pypy3
+envlist = py36, py37, py38, py39, pypy3
 
 [testenv]
 deps=-r{toxinidir}/requirements/dev.pip
@@ -8,7 +8,7 @@ allowlist_externals=
     mypy
 sitepackages=False
 
-[testenv:py{36,37,38}]
+[testenv:py{36,37,38,39}]
 commands=
     /bin/sh -c "{env:PYPISERVER_SETUP_CMD:true}"
     # individual mypy files for now, until we get the rest


### PR DESCRIPTION
~Unfortunately travis doesn't yet have 3.9 (just 3.9-dev2)~ (update: according to [this](https://travis-ci.community/t/python-3-9-0-build/10091/18), it's available now!), but I've run 3.9.0 locally with no problems. Seems like we should start running in CI as well, since 3.9 is official.