### PR TITLE
Add --diff flag to black formatter check

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,4 +25,4 @@ jobs:
   include:
     - python: 3.8
       install: pip install -U black
-      script: black --check .
+      script: black --diff --check .


### PR DESCRIPTION
# What

This makes the output more explicit. 
Instead of just a check like this: 

```bash
$ black --check .
would reformat /home/travis/build/pypiserver/...
```

Will do a check like this showing the possible changes.

```bash
$ black --diff --check .
....
     expected_results = [
         mock_removal_change_event_class(difference=set()),
-        mock_addition_change_event_class(difference={'c'}),
+        mock_addition_change_event_class(difference={"c"}),
     ]
     mock_last_local_snapshot.return_value = expected_snapshot
     mock_local_contents.return_value = expected_local_contents
     result = list(storage_client.get_change_events())
     assert expected_results == result
would reformat tests/...
```

## Remarks:

- Check this for details: https://github.com/psf/black#command-line-options
- Not sure if that's required, but I thought it could be handy. Feel free to close :+1: 