### PR TITLE
Fix version incompatibility that breaks twine in docker test

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,8 @@ python:
   - pypy3
 
 install:
-  - pip install --use-feature 2020-resolver -U setuptools twine pip sphinx tox tox-travis
+  - pip install -U pip
+  - pip install --use-feature=2020-resolver -U setuptools twine sphinx tox tox-travis
 
 script:
   - tox
@@ -26,5 +27,7 @@ jobs:
       install: pip install -U black
       script: black --check .
     - python: 3.9
-      install: pip install --use-feature 2020-resolver -U pip twine
+      install: 
+       - pip install -U pip
+       - pip install --use-feature 2020-resolver -U twine
       script: ./bin/test-docker.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,10 +10,9 @@ python:
   - pypy3
 
 install:
-  - pip install -U setuptools twine pip sphinx tox tox-travis
+  - pip install --use-feature 2020-resolver -U setuptools twine pip sphinx tox tox-travis
 
 script:
-  - ./bin/test-docker.sh
   - tox
   - ./bin/check_readme.sh
 
@@ -23,6 +22,9 @@ branches:
 
 jobs:
   include:
-    - python: 3.8
+    - python: 3.9
       install: pip install -U black
       script: black --check .
+    - python: 3.9
+      install: pip install --use-feature 2020-resolver -U pip twine
+      script: ./bin/test-docker.sh


### PR DESCRIPTION
fixes #355 

- use the new pip resolver for dependeny installation
- run the docker tests in a separate stage