### PR TITLE
Add aggregate "tests" job

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,8 +8,6 @@ on:
     # executable, from back in the day before docker & a better pip.
     branches-ignore:
       - standalone
-  pull_request: {}
-
 
 jobs:
   test-cpython:
@@ -89,3 +87,15 @@ jobs:
       run: pip install --use-feature 2020-resolver -U twine
     - name: Run tests
       run: ./bin/test-docker.sh
+
+
+  tests:
+    runs-on: "ubuntu-latest"
+    needs:
+      - "check"
+      - "docker"
+      - "test-cpython"
+      - "test-pypy"
+    steps:
+      - name: "Everything is good!"
+        run: "echo true"


### PR DESCRIPTION
Adds an aggregate "tests" job to CI so that we can gate merges on that
without needing to keep merge gates up-to-date with the names of the
various jobs that collectively represent "all tests".

Also dropped the `pull-request` trigger, which I included originally
because I wasn't sure whether the tests on push would run for forks,
which they do!