### PR TITLE
Gunicorn/gevent docker, log fixes, cache busting

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -2,6 +2,7 @@
 !pypiserver
 !requirements
 !docker/docker-requirements.txt
+!docker/gunicorn.conf.py
 !docker/entrypoint.sh
 !README.rst
 !setup.cfg

--- a/Dockerfile
+++ b/Dockerfile
@@ -31,26 +31,37 @@ RUN apk add --no-cache --virtual .build-deps \
 
 FROM base AS builder_dependencies
 
-COPY pypiserver /code/pypiserver
-COPY requirements /code/requirements
-COPY docker/docker-requirements.txt /code
-COPY setup.cfg /code
-COPY setup.py /code
-COPY README.rst /code
+WORKDIR /code
 
+COPY docker/docker-requirements.txt .
+
+# Install requirements
 RUN apk add --no-cache --virtual .build-deps \
         build-base \
         libffi-dev \
     && mkdir /install \
-    && python -m pip install --no-warn-script-location \
-                --prefix=/install \
-                /code --requirement /code/docker-requirements.txt
+    && python -m pip install \
+        --no-warn-script-location \
+        --prefix=/install \
+        --requirement docker-requirements.txt
+
+# Install pypiserver
+# - do this separately from deps so that when developing, every change does not
+#   require reinstalling deps
+COPY pypiserver pypiserver
+COPY setup.cfg .
+COPY setup.py .
+COPY README.rst .
+RUN python -m pip install --no-warn-script-location --prefix=/install .
 
 FROM base
+
+WORKDIR /data
 # Copy the libraries installed via pip
 COPY --from=builder_dependencies /install /usr/local
 COPY --from=builder_gosu /usr/local/bin/gosu /usr/local/bin/gosu
 COPY docker/entrypoint.sh /entrypoint.sh
+COPY docker/gunicorn.conf.py /data
 
 # Use a consistent user and group ID so that linux users
 # can create a corresponding system user and set permissions
@@ -64,10 +75,11 @@ RUN apk add bash \
     && chmod +x /entrypoint.sh 
 
 VOLUME /data/packages
-WORKDIR /data
 ENV PYPISERVER_PORT=8080
 # PORT is deprecated. Please use PYPISERVER_PORT instead
 ENV PORT=$PYPISERVER_PORT
+# Flush logs immediately to stdout
+ENV PYTHONUNBUFFERED=t
 EXPOSE $PYPISERVER_PORT
 
 ENTRYPOINT ["/entrypoint.sh"]

--- a/docker/docker-requirements.txt
+++ b/docker/docker-requirements.txt
@@ -1,3 +1,5 @@
-passlib==1.7.2
-bcrypt==3.1.7
-watchdog==0.10.3
+gevent==21.1.2
+gunicorn==20.0.4
+passlib==1.7.4
+bcrypt==3.2.0
+watchdog==1.0.2

--- a/docker/docker-requirements.txt
+++ b/docker/docker-requirements.txt
@@ -1,5 +1,11 @@
+# We use gunicorn as the default server in the docker container, with gevent
+# workers
 gevent==21.1.2
 gunicorn==20.0.4
 passlib==1.7.4
 bcrypt==3.2.0
+# If a user overrides args but does not override the server arg, we fall back to
+# whatever bottle chooses as a default. Since the wsgiref server is not
+# production-ready, install waitress as a fallback for these cases.
+waitress==1.4.4
 watchdog==1.0.2

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -117,7 +117,9 @@ fi
 
 
 if [[ "$*" == "" ]]; then
-    CMD=("run" "-p" "${PYPISERVER_PORT:-$PORT}")
+    # Use the gunicorn server by default, since it's more performant than
+    # bottle's default server
+    CMD=("run" "-p" "${PYPISERVER_PORT:-$PORT}" "--server" "gunicorn")
 else
     # this reassigns the array to the CMD variable
     CMD=( "${@}" )

--- a/docker/gunicorn.conf.py
+++ b/docker/gunicorn.conf.py
@@ -1,0 +1,14 @@
+"""Default gunicorn config for the docker environment.
+
+To override, mount a new gunicorn config at /data/gunicorn.conf.py in your
+Docker container.
+"""
+
+# pylint: disable=invalid-name
+
+# Enable to log every request
+# accesslog = "-"
+errorlog = "-"
+preload_app = True
+workers = 1
+worker_class = "gevent"

--- a/pypiserver/__main__.py
+++ b/pypiserver/__main__.py
@@ -6,21 +6,27 @@ from __future__ import print_function
 import logging
 import sys
 import typing as t
+from pathlib import Path
+from wsgiref.simple_server import WSGIRequestHandler
 
 import functools as ft
 from pypiserver.config import Config, UpdateConfig
+
+if t.TYPE_CHECKING:
+    import pypiserver.bottle  # noqa pylint: disable=unused-import
 
 
 log = logging.getLogger("pypiserver.main")
 
 
 def init_logging(
-    level=logging.NOTSET,
-    frmt=None,
-    filename=None,
+    level: int = logging.NOTSET,
+    frmt: str = None,
+    filename: t.Union[str, Path] = None,
     stream: t.Optional[t.IO] = sys.stderr,
-    logger=None,
-):
+    logger: logging.Logger = None,
+) -> None:
+    """Configure the specified logger, or the root logger otherwise."""
     logger = logger or logging.getLogger()
     logger.setLevel(level)
 
@@ -36,14 +42,132 @@ def init_logging(
         logger.addHandler(handler)
 
 
-def main(argv=None):
+class WsgiHandler(WSGIRequestHandler):
+    """A simple request handler to configure logging."""
+
+    # The default `FixedHandler` that bottle's `WSGIRefServer` uses does not
+    # log in a particularly predictable or configurable way. We'll pass this
+    # in to use instead.
+    def address_string(self) -> str:  # Prevent reverse DNS lookups please.
+        # This method copied directly from bottle's `FixedHandler` and
+        # maintained on the Chesterton's fence principle (i.e. I don't know
+        # why it's important, so I'm not going to get rid of it)
+        return self.client_address[0]
+
+    def log_message(
+        self, format: str, *args: t.Any  # pylint: disable=redefined-builtin
+    ) -> None:
+        """Log a message."""
+        # The log_message method on the `HttpRequestHandler` base class just
+        # writes directly to stderr. We'll use its same formatting, but pass
+        # it through the logger instead.
+        log.info(
+            "%s - - [%s] %s\n",
+            self.address_string(),
+            self.log_date_time_string(),
+            format % args,
+        )
+
+
+class ServerCheck:
+    """Methods to check for a server's presence in the import path."""
+
+    # Because we need to potentially override behavior for different servers
+    # by passing options into bottle's `run` method, and because those options
+    # aren't necessarily compatible between servers, we need to be able to guess
+    # which server bottle will pick if the user specifies the `auto` server
+    # type. These methods' names match the `__name__` property of the server
+    # adapters in bottle, so we can filter the adapters on the `AutoServer`
+    # adapter to figure out which ones are present. Since bottle uses the
+    # first server to successfully import from that same list, this should
+    # be sufficient to give us good certainty as to which server it will run.
+
+    # pylint: disable=missing-function-docstring
+    # pylint: disable=invalid-name
+    # pylint: disable=import-outside-toplevel
+    # pylint: disable=unused-import
+
+    @staticmethod
+    def WaitressServer() -> bool:
+        try:
+            import waitress  # noqa: F401
+
+            return True
+        except ImportError:
+            return False
+
+    @staticmethod
+    def PasteServer() -> bool:
+        try:
+            import paste  # noqa: F401
+
+            return True
+        except ImportError:
+            return False
+
+    @staticmethod
+    def TwistedServer() -> bool:
+        try:
+            import twisted.web  # noqa: F401
+
+            return True
+        except ImportError:
+            return False
+
+    @staticmethod
+    def CherryPyServer() -> bool:
+        try:
+            import cheroot.wsgi  # noqa: F401
+
+            return True
+        except ImportError:
+            try:
+                import cherrypy.wsgiserver  # noqa: F401
+
+                return True
+            except ImportError:
+                return False
+
+    @staticmethod
+    def WSGIRefServer() -> bool:
+        try:
+            import wsgiref  # noqa: F401
+
+            return True
+        except ImportError:
+            return False
+
+    # pylint: enable=missing-function-docstring
+    # pylint: enable=invalid-name
+    # pylint: enable=import-outside-toplevel
+    # pylint: enable=unused-import
+
+
+def guess_auto_server() -> "t.Type[pypiserver.bottle.ServerAdapter]":
+    """Guess which server bottle will use for the auto setting."""
+    # pylint: disable=import-outside-toplevel
+    import pypiserver.bottle  # pylint: disable=redefined-outer-name
+
+    # Return the first ServerAdapter in `AutoServer.adapters` whose
+    # corresponding method in `ServerCheck` returns True. If none of the
+    # servers import correctly, `next()` will raise a `StopIteration` error.
+    return next(
+        filter(
+            lambda s: getattr(ServerCheck, s.__name__)(),
+            pypiserver.bottle.AutoServer.adapters,
+        )
+    )
+
+
+def main(argv: t.Sequence[str] = None) -> None:
     """Application entrypoint for pypiserver.
 
     This function drives the application (as opposed to the library)
     implementation of pypiserver. Usage from the commandline will result in
     this function being called.
     """
-    import pypiserver
+    # pylint: disable=import-outside-toplevel
+    import pypiserver  # pylint: disable=redefined-outer-name
 
     if argv is None:
         # The first item in sys.argv is the name of the python file being
@@ -84,25 +208,52 @@ def main(argv=None):
     from pypiserver import bottle
 
     bottle.debug(config.verbosity > 1)
-    bottle._stderr = ft.partial(
+    bottle._stderr = ft.partial(  # pylint: disable=protected-access
         _logwrite, logging.getLogger(bottle.__name__), logging.INFO
     )
 
     # Here `app` is a Bottle instance, which we pass to bottle.run() to run
     # the server
     app = pypiserver.app_from_config(config)
+
+    if config.server_method == "gunicorn":
+        # When bottle runs gunicorn, gunicorn tries to pull its arguments from
+        # sys.argv. Because pypiserver's arguments don't match gunicorn's,
+        # this leads to errors.
+        sys.argv = ["gunicorn"]
+
+    wsgi_kwargs = {"handler_class": WsgiHandler}
+
+    if config.server_method == "auto":
+        expected_server = guess_auto_server()
+        extra_kwargs = (
+            wsgi_kwargs if expected_server is bottle.WSGIRefServer else {}
+        )
+        log.debug(
+            "Server 'auto' selected. Expecting bottle to run '%s'. "
+            "Passing extra keyword args: %s",
+            expected_server.__name__,
+            extra_kwargs,
+        )
+    else:
+        extra_kwargs = wsgi_kwargs if config.server_method == "wsgiref" else {}
+        log.debug(
+            "Running bottle with selected server '%s'", config.server_method
+        )
+
     bottle.run(
         app=app,
         host=config.host,
         port=config.port,
         server=config.server_method,
+        **extra_kwargs,
     )
 
 
 def _logwrite(logger, level, msg):
     if msg:
         line_endings = ["\r\n", "\n\r", "\n"]
-        for le in line_endings:
+        for le in line_endings:  # pylint: disable=invalid-name
             if msg.endswith(le):
                 msg = msg[: -len(le)]
         if msg:

--- a/pypiserver/_app.py
+++ b/pypiserver/_app.py
@@ -223,7 +223,7 @@ def handle_rpc():
         .childNodes[0]
         .wholeText.strip()
     )
-    log.info(f"Processing RPC2 request for '{methodname}'")
+    log.debug(f"Processing RPC2 request for '{methodname}'")
     if methodname == "search":
         value = (
             parser.getElementsByTagName("string")[0]

--- a/pypiserver/backend.py
+++ b/pypiserver/backend.py
@@ -167,6 +167,15 @@ class CachingFileBackend(SimpleFileBackend):
 
         self.cache_manager = cache_manager or CacheManager()  # type: ignore
 
+    def add_package(self, filename: str, stream: t.BinaryIO) -> None:
+        write_file(stream, self.roots[0].joinpath(filename))
+        self.cache_manager.invalidate_root_cache(self.roots[0])
+
+    def remove_package(self, pkg: PkgFile) -> None:
+        if pkg.fn is not None:
+            os.remove(pkg.fn)
+        self.cache_manager.invalidate_root_cache(pkg.root)
+
     def get_all_packages(self) -> t.Iterable[PkgFile]:
         return itertools.chain.from_iterable(
             self.cache_manager.listdir(r, listdir) for r in self.roots

--- a/pypiserver/backend.py
+++ b/pypiserver/backend.py
@@ -2,6 +2,7 @@ import abc
 import functools
 import hashlib
 import itertools
+import logging
 import os
 import typing as t
 from pathlib import Path
@@ -16,6 +17,9 @@ from .pkg_helpers import (
 
 if t.TYPE_CHECKING:
     from .config import _ConfigCommon as Configuration
+
+
+log = logging.getLogger(__name__)
 
 
 PathLike = t.Union[str, os.PathLike]
@@ -147,7 +151,15 @@ class SimpleFileBackend(Backend):
 
     def remove_package(self, pkg: PkgFile) -> None:
         if pkg.fn is not None:
-            os.remove(pkg.fn)
+            try:
+                os.remove(pkg.fn)
+            except FileNotFoundError:
+                log.warning(
+                    "Tried to remove %s, but it is already gone", pkg.fn
+                )
+            except OSError:
+                log.exception("Unexpected error removing package: %s", pkg.fn)
+                raise
 
     def exists(self, filename: str) -> bool:
         return any(
@@ -168,12 +180,11 @@ class CachingFileBackend(SimpleFileBackend):
         self.cache_manager = cache_manager or CacheManager()  # type: ignore
 
     def add_package(self, filename: str, stream: t.BinaryIO) -> None:
-        write_file(stream, self.roots[0].joinpath(filename))
+        super().add_package(filename, stream)
         self.cache_manager.invalidate_root_cache(self.roots[0])
 
     def remove_package(self, pkg: PkgFile) -> None:
-        if pkg.fn is not None:
-            os.remove(pkg.fn)
+        super().remove_package(pkg)
         self.cache_manager.invalidate_root_cache(pkg.root)
 
     def get_all_packages(self) -> t.Iterable[PkgFile]:

--- a/requirements/test.pip
+++ b/requirements/test.pip
@@ -5,7 +5,7 @@ gevent>=1.1b4; python_version >= '3'
 httpx
 pip
 passlib>=1.6
-pytest>=6
+pytest>=6.2.2
 pytest-cov
 setuptools
 tox

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -8,6 +8,7 @@ from unittest import mock
 
 import pytest
 
+import pypiserver.bottle
 from pypiserver import __main__
 from pypiserver.bottle import Bottle
 
@@ -84,6 +85,22 @@ def test_port(main):
 def test_server(main):
     assert main(["--server=paste"])["server"] == "paste"
     assert main(["--server", "cherrypy"])["server"] == "cherrypy"
+
+
+def test_wsgiserver_extra_args_present(monkeypatch, main):
+    """The wsgi server gets extra keyword arguments."""
+    monkeypatch.setattr(
+        __main__, "guess_auto_server", lambda: pypiserver.bottle.WSGIRefServer
+    )
+    assert main([])["handler_class"] is __main__.WsgiHandler
+
+
+def test_wsgiserver_extra_kwargs_absent(monkeypatch, main):
+    """Other servers don't get wsgiserver args."""
+    monkeypatch.setattr(
+        __main__, "guess_auto_server", lambda: pypiserver.bottle.WaitressServer
+    )
+    assert "handler_class" not in main([])
 
 
 def test_root_multiple(main):

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -67,14 +67,18 @@ def test_noargs(main):
     # Assert we're calling with the default host, port, and server, and
     # assume that we've popped `app` off of the bottle args in our `main`
     # fixture.
-    assert main([]) == {"host": "0.0.0.0", "port": 8080, "server": "auto"}
+    exp_kwargs = {"host": "0.0.0.0", "port": 8080, "server": "auto"}
+    actual_kwargs = main([])
+    # Only assert our expected are are present. We may pass extra kwargs
+    # for particular servers, depending on what is available in the python
+    # path.
+    assert all(map(lambda k: exp_kwargs[k] == actual_kwargs[k], exp_kwargs))
 
 
 def test_port(main):
-    expected = dict(host="0.0.0.0", port=8081, server="auto")
-    assert main(["--port=8081"]) == expected
-    assert main(["--port", "8081"]) == expected
-    assert main(["-p", "8081"]) == expected
+    assert main(["--port=8081"])["port"] == 8081
+    assert main(["--port", "8081"])["port"] == 8081
+    assert main(["-p", "8081"])["port"] == 8081
 
 
 def test_server(main):


### PR DESCRIPTION
Updates the Docker configuration to use the gunicorn server with gevent
workers by default. Hopefully this will resolve the symptoms seen when
running pypiserver with the non-production grade wsgiref server as
reported in #286.

Making this happen brought a few other issues to light, which are also
addressed here.

- Docker log output not immediately being flushed to stdout (#358):
  resolved by setting the `PYTHONUNBUFFERED` env var to `t` in the
  docker container
- When the WSGIRef server is selected, its access logs are written
  directly to stderr, rather than going through the logging machinery:
  resolved by adding a new `WsgiHandler` class and passing in to
  bottle's `run()` method when running the wsgi server. This required a
  new `ServerCheck` class to determine whether the wsgi server is
  selected when the `auto` option is used
- When using `gunicorn` along with the watchdog cache, package uplaods
  were not being picked up by the watcher. Updated the `add_package`
  and `remove_package` methods on the `CachingFileBackend` to bust the
  cache
- The Dockerfile was not really amenable to local development, since any
  change to code led to all the dependencies being reinstalled. Updated the
  file so that dependencies can be cached as a separate image from code.

---

Resolves #358 