### PR TITLE
Push to Docker Hub from CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,8 +1,9 @@
 # Run tests
 
-name: Test
+name: CI
 
 on:
+  # This will run when any branch or tag is pushed
   push:
     # standalone is an old branch containing a fully functional pypiserver
     # executable, from back in the day before docker & a better pip.
@@ -108,3 +109,82 @@ jobs:
     steps:
       - name: "Everything is good!"
         run: "echo true"
+
+  # figure out which docker tags we need to push
+  docker-determine-tags:
+    runs-on: "ubuntu-latest"
+    needs:
+      - "tests"
+    steps:
+      - uses: "actions/checkout@v2"
+
+      - uses: "actions/setup-python@v2"
+        with:
+          python-version: "3.9"
+
+        # This script prints a JSON array of needed docker tags, depending on the
+        # ref. That array is then used to construct the matrix of the
+        # deploy-docker job
+      - name: "Get expected docker tags"
+        id: "tags"
+        run: >-
+          echo "::set-output name=tags::$(bin/ci_helper.py ${{ github.ref }} docker_tags)"
+
+        # This is needed because GH actions will fail on an empty matrix, so
+        # we need to be sure the `if` condition is false on the next job if
+        # the matrix will be empty. The script prints 'true' if the array is
+        # not empty, or 'false' otherwise.
+      - name: "Determine whether any tags are needed"
+        id: "has_tags"
+        run: >-
+          echo "::set-output name=has_tags::$(bin/ci_helper.py ${{ github.ref }} has_tags)"
+
+    outputs:
+      tags: "${{ steps.tags.outputs.tags }}"
+      has_tags: "${{ steps.has_tags.outputs.has_tags }}"
+
+  # Deploy any needed docker tags
+  deploy-docker:
+    runs-on: "ubuntu-latest"
+    needs:
+      - "tests"
+      - "docker-determine-tags"
+    if: "${{ fromJson(needs.docker-determine-tags.outputs.has_tags) }}"
+    strategy:
+      matrix:
+        tag: "${{ fromJson(needs.docker-determine-tags.outputs.tags) }}"
+    steps:
+      - uses: "actions/checkout@v2"
+
+      - name: "Cache Docker layers"
+        uses: "actions/cache@v2"
+        with:
+          path: "/tmp/.buildx-cache"
+          key: "${{ runner.os }}-buildx-${{ github.sha }}"
+          restore-keys: |
+            ${{ runner.os }}-buildx-
+
+      - name: "Login to Docker Hub"
+        uses: "docker/login-action@v1"
+        with:
+          username: "${{ secrets.DOCKER_HUB_USER }}"
+          password: "${{ secrets.DOCKER_HUB_TOKEN }}"
+
+      - name: "Set up Docker Buildx"
+        id: "buildx"
+        uses: "docker/setup-buildx-action@v1"
+
+      - name: "Build and push"
+        id: "docker_build"
+        uses: "docker/build-push-action@v2"
+        with:
+          context: "./"
+          file: "./Dockerfile"
+          builder: "${{ steps.buildx.outputs.name }}"
+          push: true
+          tags:  "pypiserver/pypiserver:${{ matrix.tag }}"
+          cache-from: "type=local,src=/tmp/.buildx-cache"
+          cache-to: "type=local,dest=/tmp/.buildx-cache"
+
+      - name: "Image digest"
+        run: "echo ${{ steps.docker_build.outputs.digest }}"

--- a/bin/ci_helper.py
+++ b/bin/ci_helper.py
@@ -1,0 +1,88 @@
+#!/usr/bin/env python3
+
+"""Output expected docker tags to build in CI."""
+
+import json
+import typing as t
+import re
+from argparse import ArgumentParser, Namespace
+
+
+RELEASE_RE = re.compile(r"v[0-9]+\.[0-9]+\.[0-9]+(\.post[0-9]+)?")
+PRE_RELEASE_RE = re.compile(r"v[0-9]+\.[0-9]+\.[0-9]+(a|b|c|\.?dev)[0-9]+")
+
+
+def parse_args() -> Namespace:
+    """Parse cmdline args."""
+    parser = ArgumentParser()
+    parser.add_argument(
+        "ref",
+        help=(
+            "The github ref for which CI is running. This may be a full ref "
+            "like refs/tags/v1.2.3 or refs/heads/master, or just a tag/branch "
+            "name like v1.2.3 or master."
+        ),
+    )
+    parser.add_argument(
+        "action",
+        help=("The action to perform"),
+        choices=("docker_tags", "pypi_release", "has_tags"),
+    )
+    return parser.parse_args()
+
+
+def strip_ref_to_name(ref: str) -> str:
+    """Strip a full ref to a name."""
+    strips = ("refs/heads/", "refs/tags/")
+    for strip in strips:
+        if ref.startswith(strip):
+            return ref[len(strip) :]
+    return ref
+
+
+def name_to_array(name: str) -> t.Tuple[str, ...]:
+    """Convert a ref name to an array of tags to build."""
+    tags: t.Dict[str, t.Callable[[str], bool]] = {
+        # unstable for any master build
+        "unstable": lambda i: i == "master",
+        # latest goes for full releases
+        "latest": lambda i: RELEASE_RE.fullmatch(i) is not None,
+        # the tag itself for any release or pre-release tag
+        name: lambda i: (
+            RELEASE_RE.fullmatch(i) is not None
+            or PRE_RELEASE_RE.fullmatch(i) is not None
+        ),
+    }
+    return tuple(tag for tag, test in tags.items() if test(name))
+
+
+def ref_to_json(ref: str) -> str:
+    """Convert a ref to a JSON array and return it as a string."""
+    array = name_to_array(strip_ref_to_name(ref))
+    return json.dumps(array)
+
+
+def should_deploy_to_pypi(ref: str) -> str:
+    """Return a JSON bool indicating whether we should deploy to PyPI."""
+    name = strip_ref_to_name(ref)
+    return json.dumps(
+        RELEASE_RE.fullmatch(name) is not None
+        or PRE_RELEASE_RE.fullmatch(name) is not None
+    )
+
+
+def main() -> None:
+    """Parse args and print the JSON array."""
+    args = parse_args()
+    action_switch: t.Dict[str, t.Callable[[], None]] = {
+        "docker_tags": lambda: print(ref_to_json(args.ref)),
+        "has_tags": lambda: print(
+            json.dumps(len(name_to_array(strip_ref_to_name(args.ref))) > 0)
+        ),
+        "pypi_release": lambda: print(should_deploy_to_pypi(args.ref)),
+    }
+    action_switch[args.action]()
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Adds a new helper script to determine which docker tags are needed for a
given ref going through CI, and uses those tags to populate the GH
actions matrix for a docker deploy step.

Resolves #373 