### PR TITLE
Add option to allow only overwriting development releases

### DIFF
--- a/README.md
+++ b/README.md
@@ -267,6 +267,8 @@ optional arguments:
                         one of paste, cherrypy, twisted, or wsgiref.
   -o, --overwrite       Allow overwriting existing package files during
                         upload.
+  --overwrite-dev       Allow overwriting existing package files during upload,
+                        only for development releases.
   --welcome HTML_FILE   Use the contents of HTML_FILE as a custom welcome
                         message on the home page.
   --cache-control AGE   Add "Cache-Control: max-age=AGE" header to package

--- a/pypiserver/__init__.py
+++ b/pypiserver/__init__.py
@@ -193,6 +193,10 @@ def paste_app_factory(_global_config, **local_conf):
         """Convert a specified string root into an absolute Path instance."""
         return pathlib.Path(root.strip()).expanduser().resolve()
 
+    def to_overwrite(val: t.Optional[str]) -> t.Optional[t.Union[bool, str]]:
+        """Convert a string value, if provided, to a bool or "dev"."""
+        return val if val == "dev" else to_bool(val)
+
     # A map of config keys we expect in the paste config to the appropriate
     # function to parse the string config value. This map includes both
     # current and legacy keys.
@@ -204,7 +208,7 @@ def paste_app_factory(_global_config, **local_conf):
         "disable_fallback": to_bool,
         # redirect_to_fallback is a deprecated argument for disable_fallback
         "redirect_to_fallback": to_bool,
-        "overwrite": to_bool,
+        "overwrite": to_overwrite,
         "authenticate": functools.partial(to_list, sep=" "),
         # authenticated is a deprecated argument for authenticate
         "authenticated": functools.partial(to_list, sep=" "),

--- a/pypiserver/_app.py
+++ b/pypiserver/_app.py
@@ -23,7 +23,11 @@ from .bottle import (
     Bottle,
     template,
 )
-from .pkg_helpers import guess_pkgname_and_version, normalize_pkgname_for_url
+from .pkg_helpers import (
+    guess_pkgname_and_version,
+    normalize_pkgname_for_url,
+    parse_version,
+)
 
 log = logging.getLogger(__name__)
 config: RunConfig
@@ -160,22 +164,29 @@ def file_upload():
     for uf in ufiles:
         if not uf:
             continue
-        if (
-            not is_valid_pkg_filename(uf.raw_filename)
-            or guess_pkgname_and_version(uf.raw_filename) is None
-        ):
+        if is_valid_pkg_filename(uf.raw_filename):
+            name_version = guess_pkgname_and_version(uf.raw_filename)
+        else:
+            name_version = None
+        if name_version is None:
             raise HTTPError(400, f"Bad filename: {uf.raw_filename}")
 
-        if not config.overwrite and config.backend.exists(uf.raw_filename):
-            log.warning(
-                f"Cannot upload {uf.raw_filename!r} since it already exists! \n"
-                "  You may start server with `--overwrite` option. "
-            )
-            raise HTTPError(
-                409,
-                f"Package {uf.raw_filename!r} already exists!\n"
-                "  You may start server with `--overwrite` option.",
-            )
+        if config.backend.exists(uf.raw_filename):
+            if config.overwrite == "dev":
+                allow_overwrite = "*@" in parse_version(name_version[1])
+            else:
+                allow_overwrite = config.overwrite
+            if not allow_overwrite:
+                log.warning(
+                    f"Cannot upload {uf.raw_filename!r} since it already "
+                    "exists! \n"
+                    "  You may start server with `--overwrite` option. "
+                )
+                raise HTTPError(
+                    409,
+                    f"Package {uf.raw_filename!r} already exists!\n"
+                    "  You may start server with `--overwrite` option.",
+                )
 
         config.backend.add_package(uf.raw_filename, uf.file)
         if request.auth:

--- a/pypiserver/config.py
+++ b/pypiserver/config.py
@@ -433,6 +433,16 @@ def get_parser() -> argparse.ArgumentParser:
         help="Allow overwriting existing package files during upload.",
     )
     run_parser.add_argument(
+        "--overwrite-dev",
+        action="store_const",
+        const="dev",
+        dest="overwrite",
+        help=(
+            "Allow overwriting existing package files during upload, only for "
+            "development releases."
+        ),
+    )
+    run_parser.add_argument(
         "--welcome",
         metavar="HTML_FILE",
         # we want to run our `html_file_arg` function to get our default value
@@ -683,7 +693,7 @@ class RunConfig(_ConfigCommon):
         fallback_url: str,
         health_endpoint: str,
         server_method: str,
-        overwrite: bool,
+        overwrite: t.Union[bool, str],
         welcome_msg: str,
         cache_control: t.Optional[int],
         log_req_frmt: str,

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -439,6 +439,13 @@ _CONFIG_TEST_PARAMS: t.Tuple[ConfigTestCase, ...] = (
         exp_config_type=RunConfig,
         exp_config_values={"overwrite": True},
     ),
+    ConfigTestCase(
+        case="Run: overwrite-dev set",
+        args=["run", "--overwrite-dev"],
+        legacy_args=["--overwrite-dev"],
+        exp_config_type=RunConfig,
+        exp_config_values={"overwrite": "dev"},
+    ),
     # hash-algo
     ConfigTestCase(
         case="Run: hash-algo unspecified",


### PR DESCRIPTION
I like the security of not allowing packages with the same version to be overwritten if I forget to bump the version number. However, I'd like to have an automated build job that publishes a development release any time I push to my development branch. Rather than have to remember to edit the version with every commit I push, I want this automated build to automatically add a .dev0 suffix to make sure it is publishing dev releases. I don't want it to have to determine the highest dev version number to increment and I don't mind overwriting these. I could just turn `--overwrite` on, but I thought that this was a reasonable use case to have an option that only allowed overwriting of dev releases. So I added a `--overwrite-dev` option that does that.

Internally, it writes to the same config option, so now the option can have 3 possible values: False (no overwrite), True (overwrite any package), "dev" (overwrite only dev releases). I'd be happy to switch it to a real enum if you'd prefer.