### PR TITLE
Correct README example

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -62,7 +62,7 @@ not officially supported, and will not receive bugfixes or new features.
 
 1. Install ``pypiserver`` with this command::
 
-    pip install pypiserver                # Or: pypiserver[passlib,watchdog]
+    pip install pypiserver                # Or: pypiserver[passlib,cache]
     mkdir ~/packages                      # Copy packages into this directory.
 
    See also `Alternative Installation methods`_.


### PR DESCRIPTION
The readme incorrectly specifies `watchdog` as the name of the extra to install. It's actually specified as `cache`. see: https://github.com/pypiserver/pypiserver/blob/df300de33d2ffe01f218396813433f23001dd76b/setup.py#L49