### PR TITLE
Contributor documentation directory and README

### DIFF
--- a/contributor_docs/README.md
+++ b/contributor_docs/README.md
@@ -1,0 +1,25 @@
+# Hello
+
+Welcome to the contributor's documentation section of `pypiserver`.  
+Here you can find the information about inner working of the system.  
+Contributions and support in maintaining (both the project and these documents)
+is very welcome :v:  
+
+> This documentation is still a work in progress and would benefit from
+    your help!  
+> Some areas to describe are highlighted in
+    [this issue](https://github.com/pypiserver/pypiserver/issues/368),
+    but feel free to add if you see something missing there.  
+> All the help will be very appreciated! :)  
+
+## Find more information
+
+If something is missing in the documentation here, try checking in the
+`README.rst` and if it's still not there, don't hesistate to contribute.  
+
+## Documentation organization
+
+This folder contains various documents describing the `pypiserver` that might
+be of interest to someone studying it in more details.  
+The documentation files are written in `.md` and it will be great if new
+files are added in the same format.  

--- a/contributor_docs/README.md
+++ b/contributor_docs/README.md
@@ -1,7 +1,7 @@
 # Hello
 
 Welcome to the contributor's documentation section of `pypiserver`.  
-Here you can find the information about inner working of the system.  
+Here you can find information about the inner working of the system.  
 Contributions and support in maintaining (both the project and these documents)
 is very welcome :v:  
 
@@ -15,7 +15,7 @@ is very welcome :v:
 ## Find more information
 
 If something is missing in the documentation here, try checking in the
-`README.rst` and if it's still not there, don't hesistate to contribute.  
+`README.rst` and if it's still not there, don't hesitate to contribute.  
 
 ## Documentation organization
 

--- a/contributor_docs/architecture_overview.md
+++ b/contributor_docs/architecture_overview.md
@@ -1,0 +1,3 @@
+# Architecture Overview
+
+To be described...


### PR DESCRIPTION
# What

This pull request adds a section for the contributor docs and a basic architecture overview as an example.    
Decided to keep the pull request short and maybe, for the starters, just providing a space for adding documentation will give a possibility for others to contribute in parallel :) 

## Changes

- introduced `./contributor_docs/` folder for extra documentation (inspired by the example of [`p5.js`'s repository structure](https://github.com/processing/p5.js))
- added a `README.md` as an introduction to the docs folder (Should be improved and proofread :))
- added a WIP architecture document (is picked up in a [separate branch](https://github.com/dee-me-tree-or-love/pypiserver/blob/368_update-contributor-docs_first-setup_arch/contributor_docs/architecture_overview.md)) 

## Related

- #368 