### PR TITLE
added JSON Topic for use with micropython-upip

### DIFF
--- a/pypiserver/__init__.py
+++ b/pypiserver/__init__.py
@@ -7,7 +7,7 @@ import typing as t
 from pypiserver.bottle import Bottle
 from pypiserver.config import Config, RunConfig, strtobool
 
-version = __version__ = "2.0.0dev1aw"
+version = __version__ = "2.0.0dev1"
 __version_info__ = tuple(_re.split("[.-]", __version__))
 __updated__ = "2020-10-11 11:23:15"
 

--- a/pypiserver/__init__.py
+++ b/pypiserver/__init__.py
@@ -7,7 +7,7 @@ import typing as t
 from pypiserver.bottle import Bottle
 from pypiserver.config import Config, RunConfig, strtobool
 
-version = __version__ = "2.0.0dev1"
+version = __version__ = "2.0.0dev1aw"
 __version_info__ = tuple(_re.split("[.-]", __version__))
 __updated__ = "2020-10-11 11:23:15"
 

--- a/pypiserver/_app.py
+++ b/pypiserver/_app.py
@@ -370,13 +370,13 @@ def json_info(project):
         config.backend.find_project_packages(project),
         key=lambda x: x.parsed_version, reverse=True
     )
-    max_version = packages[0].version
+    latest_version = packages[0].version
     releases = {}
     req_url = request.url
     for x in packages:
         releases[x.version] = [{"url": urljoin(req_url, "../../packages/" + x.relfn)}]
     rv = {
-        "info" : {"version": max_version},
+        "info" : {"version": latest_version},
         "releases" : releases
     }
     response.content_type = 'application/json'


### PR DESCRIPTION
This patch adds a json-info url to pypiserver, which is needed for micropython-upip.

The change enables pypi-server to be used as local package server for micropython projects.

If server is queried like this: http://gretel-2:8080/pypiserver/json it returns this JSON data:

```
{
"info": {"version": "2.0.0.dev1"}, 
"releases": {
  "2.0.0.dev1": [{"url": "http://gretel-2:8080/packages/pypiserver-2.0.0.dev1.zip"}], 
  "2.0.0dev1aw": [{"url": "http://gretel-2:8080/packages/pypiserver-2.0.0dev1aw.zip"}]
 }
}
```

I would be happy, if this change can make it to the master branch.

Best Regards, Axel.
