### PR TITLE
CI/CD Check fixes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,7 +62,9 @@ jobs:
         # Pretty much any python version will do
         python-version: "3.9"
     - name: Install dependencies
-      run: pip install -r "requirements/dev.pip"
+      run: |
+        pip install -r "requirements/dev.pip"
+        pip install types-pkg_resources # one of mypy required stubs
     - name: Check types
       # individual mypy files for now, until we get the rest
       # of the project typechecking

--- a/pypiserver/_app.py
+++ b/pypiserver/_app.py
@@ -363,6 +363,7 @@ def server_static(filename):
 
     return HTTPError(404, f"Not Found ({filename} does not exist)\n\n")
 
+
 @app.route("/:project/json")
 @auth("list")
 def json_info(project):
@@ -373,7 +374,8 @@ def json_info(project):
 
     packages = sorted(
         config.backend.find_project_packages(project),
-        key=lambda x: x.parsed_version, reverse=True
+        key=lambda x: x.parsed_version,
+        reverse=True,
     )
 
     if not packages:
@@ -383,12 +385,11 @@ def json_info(project):
     releases = {}
     req_url = request.url
     for x in packages:
-        releases[x.version] = [{"url": urljoin(req_url, "../../packages/" + x.relfn)}]
-    rv = {
-        "info" : {"version": latest_version},
-        "releases" : releases
-    }
-    response.content_type = 'application/json'
+        releases[x.version] = [
+            {"url": urljoin(req_url, "../../packages/" + x.relfn)}
+        ]
+    rv = {"info": {"version": latest_version}, "releases": releases}
+    response.content_type = "application/json"
     return dumps(rv)
 
 


### PR DESCRIPTION
# What 

The CI pipelines are failing on master on `check types` and `check formatting` steps. 

- [x] `mypy`: For example like in this pipeline here [run/3432212541](https://github.com/pypiserver/pypiserver/runs/3432212541?check_suite_focus=true#step:5:1):  

    ```plaintext
    Run mypy docker/test_docker.py pypiserver/config.py  tests/test_init.py
      mypy docker/test_docker.py pypiserver/config.py  tests/test_init.py
      shell: /usr/bin/bash -e {0}
      env:
        pythonLocation: /opt/hostedtoolcache/Python/3.9.6/x64
        LD_LIBRARY_PATH: /opt/hostedtoolcache/Python/3.9.6/x64/lib
    pypiserver/config.py:48:1: error: Library stubs not installed for "pkg_resources" (or incompatible with Python 3.9)
    pypiserver/config.py:48:1: note: Hint: "python3 -m pip install types-setuptools"
    pypiserver/config.py:48:1: note: (or run "mypy --install-types" to install all missing stub packages)
    pypiserver/config.py:48:1: note: See https://mypy.readthedocs.io/en/stable/running_mypy.html#missing-imports
    Found 1 error in 1 file (checked 3 source files)
    Error: Process completed with exit code 1.
    ```

    This seems to have nothing to do with the actual code, but with a missing dependency on the CI runner.  
    Probably a better fix is possible, but for the starters, this MR adds an explicit installation in the `ci.yml`.

- [x] `black`: Fixed a few styling details in `json` endpoint's code. 
