### PR TITLE
Allow GH actions to run on pull requests for forks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,6 +9,8 @@ on:
     # executable, from back in the day before docker & a better pip.
     branches-ignore:
       - standalone
+  # Allowing to run on fork pull requests
+  pull_request:
 
 jobs:
   test-cpython:


### PR DESCRIPTION
# What

Currently we do not run the GH actions CI/CD pipelines for pull requests from the forked projects although we require passing checks. This MR enables the `pull_request` as an additional trigger for GH Actions (see [docs about it](https://docs.github.com/en/actions/reference/workflow-syntax-for-github-actions#example-using-multiple-events-with-activity-types-or-configuration)).

_before_   
![image](https://user-images.githubusercontent.com/12134172/131095890-893f152f-8356-4c96-b37e-03598f0182b2.png)

_after_  
![image](https://user-images.githubusercontent.com/12134172/131096052-de30f951-9737-4f1c-b529-beb14a1704c1.png)  
> (failing mypy check is addressed in #400)


## Remarks

- See below of this Pull Request for the pipeline status
- Related to #400 aimed at fixing the failing `check-types` action