### PR TITLE
Specify doctype for generated pages.

### DIFF
--- a/pypiserver/_app.py
+++ b/pypiserver/_app.py
@@ -256,6 +256,7 @@ def handle_rpc():
 def simpleindex():
     links = sorted(config.backend.get_projects())
     tmpl = """\
+    <!DOCTYPE html>
     <html>
         <head>
             <title>Simple Index</title>
@@ -299,6 +300,7 @@ def simple(project):
     )
 
     tmpl = """\
+    <!DOCTYPE html>
     <html>
         <head>
             <title>Links for {{project}}</title>
@@ -328,6 +330,7 @@ def list_packages():
     )
 
     tmpl = """\
+    <!DOCTYPE html>
     <html>
         <head>
             <title>Index of packages</title>


### PR DESCRIPTION
This ensures compliance with PEP 503

Fixes #412