### PR TITLE
Fixed violation of PEP 503 warning with pip>=22

### DIFF
--- a/pypiserver/_app.py
+++ b/pypiserver/_app.py
@@ -256,6 +256,7 @@ def handle_rpc():
 def simpleindex():
     links = sorted(config.backend.get_projects())
     tmpl = """\
+    <!DOCTYPE html>
     <html>
         <head>
             <title>Simple Index</title>
@@ -299,6 +300,7 @@ def simple(project):
     )
 
     tmpl = """\
+    <!DOCTYPE html>
     <html>
         <head>
             <title>Links for {{project}}</title>
@@ -328,6 +330,7 @@ def list_packages():
     )
 
     tmpl = """\
+    <!DOCTYPE html>
     <html>
         <head>
             <title>Index of packages</title>


### PR DESCRIPTION
When using pip >=22, we get the following warning:

"DEPRECATION: The HTML index page being used (https://....) is not a proper
HTML 5 document. This is in violation of PEP 503 which requires these pages
to be well-formed HTML 5 documents. Please reach out to the owners of this
index page, and ask them to update this index page to a valid HTML 5
document. pip 22.2 will enforce this behaviour change. Discussion can be
found at https://github.com/pypa/pip/issues/10825"