### PR TITLE
chore(release-candidate-from-github-actions): add github action for release management

### DIFF
--- a/.github/workflows/rc.yml
+++ b/.github/workflows/rc.yml
@@ -2,11 +2,17 @@
 
 name: release_candidate
 
-# TODO:
-# 1. create a new AUTO-RC-<DATE> branch
-# 2. create a commit with bumpver & update CHANGES.rst & README.rst
-# 3. push to GH
-# 4. open a PR to `master`
+# TODO(actions):
+# - [x] create a new AUTO-RC-<DATE> branch
+# - [x] update CHANGES.rst
+# - [ ] update README.rst
+# - [ ] create bumpver commit
+# - [ ] push to GH
+# - [ ] open a PR to `master`
+
+# TODO(general):
+# - [ ] setup the action
+# - [ ] cleanup the action
 
 on:
   schedule:
@@ -15,7 +21,7 @@ on:
 
 
 jobs:
-  new-rc-branch:
+  new-rc:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
@@ -24,3 +30,5 @@ jobs:
           git config user.email github-actions@github.com
           git checkout -b auto-release-candidate-$(date +'%m-%d-%Y')
           git push -u origin auto-release-candidate-$(date +'%m-%d-%Y')
+
+          ./bin/update_changelog.sh

--- a/.github/workflows/rc.yml
+++ b/.github/workflows/rc.yml
@@ -45,7 +45,7 @@ jobs:
 
           gh pr create  --title auto-release-candidate-${RC_DATE} \
                         --body "Automated release candidate for ${RC_DATE}." \
-                        --base master
+                        --base master \
                         --draft
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/rc.yml
+++ b/.github/workflows/rc.yml
@@ -5,8 +5,10 @@ name: release_candidate
 # TODO(actions):
 # - [x] create a new AUTO-RC-<DATE> branch
 # - [x] update CHANGES.rst
+# - [x] create changes commit
+# - [x] push to GH
 # - [ ] update README.rst
-# - [ ] create bumpver commit
+# - [ ] create readme commit
 # - [ ] push to GH
 # - [ ] open a PR to `master`
 

--- a/.github/workflows/rc.yml
+++ b/.github/workflows/rc.yml
@@ -44,6 +44,8 @@ jobs:
           git push
 
           gh pr create  --title auto-release-candidate-${RC_DATE} \
-                        --body "Automated release candidate for ${RC_DATE}" \
+                        --body "Automated release candidate for ${RC_DATE}." \
                         --base master
                         --draft
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/rc.yml
+++ b/.github/workflows/rc.yml
@@ -32,5 +32,6 @@ jobs:
           git push -u origin auto-release-candidate-$(date +'%m-%d-%Y')
 
           git status
+          git fetch
 
           ./bin/update_changelog.sh

--- a/.github/workflows/rc.yml
+++ b/.github/workflows/rc.yml
@@ -1,0 +1,26 @@
+# Release Candidate GitHub Action
+
+name: release_candidate
+
+# TODO:
+# 1. create a new AUTO-RC-<DATE> branch
+# 2. create a commit with bumpver & update CHANGES.rst & README.rst
+# 3. push to GH
+# 4. open a PR to `master`
+
+on:
+  schedule:
+    - cron:  '0 0 1 * *'  # each 1st day of the month
+  workflow_dispatch:      # on manual trigger
+
+
+jobs:
+  new-rc-branch:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - run: |
+          git config user.name github-actions
+          git config user.email github-actions@github.com
+          git checkout -b auto-release-candidate-$(date +'%m-%d-%Y')
+          git push -u origin auto-release-candidate-$(date +'%m-%d-%Y')

--- a/.github/workflows/rc.yml
+++ b/.github/workflows/rc.yml
@@ -28,10 +28,11 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - run: |
+          RC_DATE=$(date +'%m-%d-%Y')
           git config user.name github-actions
           git config user.email github-actions@github.com
-          git checkout -b auto-release-candidate-$(date +'%m-%d-%Y')
-          git push -u origin auto-release-candidate-$(date +'%m-%d-%Y')
+          git checkout -b auto-release-candidate-${RC_DATE}
+          git push -u origin auto-release-candidate-${RC_DATE}
 
           git status
           git fetch
@@ -41,3 +42,8 @@ jobs:
           git add CHANGES.rst
           git commit -m "chore(rc-changes): update Changes.rst"
           git push
+
+          gh pr create  --title auto-release-candidate-${RC_DATE} \
+                        --body "Automated release candidate for ${RC_DATE}" \
+                        --base master
+                        --draft

--- a/.github/workflows/rc.yml
+++ b/.github/workflows/rc.yml
@@ -47,7 +47,7 @@ jobs:
           git commit -m "chore(rc-changes): update Changes.rst"
           git push
 
-          gh pr create  --title auto-release-candidate-${RC_DATE} \
+          gh pr create  --title "chore(auto-release-candidate-${RC_DATE})" \
                         --body "Automated release candidate for ${RC_DATE}." \
                         --base master \
                         --draft

--- a/.github/workflows/rc.yml
+++ b/.github/workflows/rc.yml
@@ -27,6 +27,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
+        with:
+          # Flag to fetch all history.
+          #   @see https://github.com/marketplace/actions/checkout#Fetch-all-history-for-all-tags-and-branches
+          fetch-depth: 0
       - run: |
           RC_DATE=$(date +'%m-%d-%Y')
           git config user.name github-actions

--- a/.github/workflows/rc.yml
+++ b/.github/workflows/rc.yml
@@ -35,3 +35,7 @@ jobs:
           git fetch
 
           ./bin/update_changelog.sh
+
+          git add CHANGES.rst
+          git commit -m "chore(rc-changes): update Changes.rst"
+          git push

--- a/.github/workflows/rc.yml
+++ b/.github/workflows/rc.yml
@@ -31,4 +31,6 @@ jobs:
           git checkout -b auto-release-candidate-$(date +'%m-%d-%Y')
           git push -u origin auto-release-candidate-$(date +'%m-%d-%Y')
 
+          git status
+
           ./bin/update_changelog.sh

--- a/.gitignore
+++ b/.gitignore
@@ -47,3 +47,5 @@ __pycache__/
 .venv/
 venv/
 
+# Release Candidate Artifacts
+rc/

--- a/bin/update_changelog.sh
+++ b/bin/update_changelog.sh
@@ -8,6 +8,8 @@
 # 3. create new RC version entry
 # 4. add change log entries
 
+# TODO: provide that as parameters?
+
 CHANGE_FILE='CHANGES.rst'
 RC_DATE=$(date +'%m-%d-%Y')
 TMP_CHANGE_LOG="./rc-${RC_DATE}.txt"

--- a/bin/update_changelog.sh
+++ b/bin/update_changelog.sh
@@ -14,7 +14,8 @@ set -e # exit on errors
 
 CHANGE_FILE='CHANGES.rst'
 RC_DATE=$(date +'%m-%d-%Y')
-TMP_CHANGE_LOG="./rc-${RC_DATE}.txt"
+WORKSPACE_DIR=${GITHUB_WORKSPACE:-.}
+TMP_CHANGE_LOG="${WORKSPACE_DIR}/rc-${RC_DATE}.txt"
 
 
 ############

--- a/bin/update_changelog.sh
+++ b/bin/update_changelog.sh
@@ -8,6 +8,8 @@
 # 3. create new RC version entry
 # 4. add change log entries
 
+set -e # exit on errors
+
 # TODO: provide that as parameters?
 
 CHANGE_FILE='CHANGES.rst'

--- a/bin/update_changelog.sh
+++ b/bin/update_changelog.sh
@@ -71,6 +71,7 @@ echo -e "$VERSION_HEADER\n" >> $TMP_CHANGE_LOG
 git log --pretty=oneline --abbrev-commit $CHANGE_DIFF_TARGETS | sed 's/^/- /' >> $TMP_CHANGE_LOG
 
 # CHECK FINAL CONTENT
+echo -e "\nCollected info:"
 ls $WORKSPACE_DIR
 cat $TMP_CHANGE_LOG
 

--- a/bin/update_changelog.sh
+++ b/bin/update_changelog.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # Script to create a new RC entry
 #

--- a/bin/update_changelog.sh
+++ b/bin/update_changelog.sh
@@ -41,11 +41,18 @@ echo "Detected last release version: $LAST_VERSION"
 # VERSION BUMPING #
 ###################
 
+
 echo "Bumping patch version..."
 MAJOR_COLUMN=1
 MINOR_COLUMN=2
 PATCH_COLUMN=3
 
+# `awk` is used to bump the PATCH version since the last public release.
+#   -F - gives a separator for splitting the original release into columns.
+#   -v - provides a value for variable to be used in the `awk` command.
+#   -v K=$PATCH_COLUMN - provides value for `K` - the version column to bump.
+# This attempts to preserve the a standard syntax for GNU Awk.
+# More can be found here: https://www.gnu.org/software/gawk/manual/gawk.html
 BUMPED_VERSION=$(echo $LAST_VERSION | awk -F. -v K=$PATCH_COLUMN '{$K+=1; print $0}' OFS='.')
 
 echo "Bumped to new candidate version: $BUMPED_VERSION"
@@ -59,8 +66,10 @@ echo "Final RC version: $RC_VERSION"
 # CHANGELOG ENTRY #
 ###################
 
+
 CHANGE_DIFF_TARGETS="v${LAST_VERSION}..HEAD"
 VERSION_TITLE="${RC_VERSION} (__rc__)"
+# Using GNU Awk syntax: -v LL specifies the title pattern variable.
 TITLE_LINE=$(awk -v LL=${#VERSION_TITLE} 'BEGIN{for(c=0;c<LL;c++) printf "-"}')
 VERSION_HEADER="$VERSION_TITLE\n${TITLE_LINE}"
 
@@ -75,15 +84,13 @@ echo -e "\nCollected info:"
 ls $WORKSPACE_DIR
 cat $TMP_CHANGE_LOG
 
-
 # APPEND INFO TO CHANGE FILE:
 #   1. Finds the first (tbd) release
-#   2. Populates space between (tbd) release with RC changes
+#   2. Populates space between (tbd) release and the latest one with RC changes
 # NB: supporting macos and linux interoperability
 #     see https://stackoverflow.com/questions/43171648/sed-gives-sed-cant-read-no-such-file-or-directory
 if [[ "$OSTYPE" == "darwin"* ]]; then
-# begin:
-# mac os support
+# begin: mac os support
 sed -i '' "/^[0-9]\.0\.0.*\(tbd\)/{N;G;r\
 \
 $TMP_CHANGE_LOG
@@ -91,8 +98,7 @@ $TMP_CHANGE_LOG
 }" $CHANGE_FILE
 # end;
 else
-# begin:
-# linux support
+# begin: linux support
 sed -i "/^[0-9]\.0\.0.*\(tbd\)/{N;G;r\
 \
 $TMP_CHANGE_LOG

--- a/bin/update_changelog.sh
+++ b/bin/update_changelog.sh
@@ -74,13 +74,30 @@ git log --pretty=oneline --abbrev-commit $CHANGE_DIFF_TARGETS | sed 's/^/- /' >>
 ls $WORKSPACE_DIR
 cat $TMP_CHANGE_LOG
 
+
 # APPEND INFO TO CHANGE FILE:
 #   1. Finds the first (tbd) release
 #   2. Populates space between (tbd) release with RC changes
+# NB: supporting macos and linux interoperability
+#     see https://stackoverflow.com/questions/43171648/sed-gives-sed-cant-read-no-such-file-or-directory
+if [[ "$OSTYPE" == "darwin"* ]]; then
+# begin:
+# mac os support
 sed -i '' "/^[0-9]\.0\.0.*\(tbd\)/{N;G;r\
 \
 $TMP_CHANGE_LOG
 \
 }" $CHANGE_FILE
+# end;
+else
+# begin:
+# linux support
+sed -i "/^[0-9]\.0\.0.*\(tbd\)/{N;G;r\
+\
+$TMP_CHANGE_LOG
+\
+}" $CHANGE_FILE
+# end;
+fi
 
 # CHANGE_LOG_CONTENTS=$(cat $TMP_CHANGE_LOG)

--- a/bin/update_changelog.sh
+++ b/bin/update_changelog.sh
@@ -81,6 +81,8 @@ echo -e "$VERSION_HEADER\n" >> $TMP_CHANGE_LOG
 
 # COLLECT ALL COMMITS:
 git log --pretty=oneline --abbrev-commit $CHANGE_DIFF_TARGETS | sed 's/^/- /' >> $TMP_CHANGE_LOG
+# DEBUG:
+git log --pretty=oneline --abbrev-commit $CHANGE_DIFF_TARGETS | sed 's/^/- /'
 
 # CHECK FINAL CONTENT
 echo -e "\nCollected info:"

--- a/bin/update_changelog.sh
+++ b/bin/update_changelog.sh
@@ -1,0 +1,68 @@
+#!/bin/bash
+
+# Script to create a new RC entry
+#
+# Actions:
+# 1. find latest published version
+# 2. find the TBD planned big version
+# 3. create new RC version entry
+# 4. add change log entries
+
+CHANGE_FILE='CHANGES.rst'
+RC_DATE=$(date +'%m-%d-%Y')
+
+echo "Updating $CHANGE_FILE:"
+
+LAST_VERSION=$(grep -m1 -E ' \([0-9]+-[0-9]+-[0-9]+\)$' $CHANGE_FILE | awk '{ print $1 }')
+
+echo "Detected last release version: $LAST_VERSION"
+
+
+###################
+# VERSION BUMPING #
+###################
+
+echo "Bumping patch version..."
+MAJOR_COLUMN=1
+MINOR_COLUMN=2
+PATCH_COLUMN=3
+
+BUMPED_VERSION=$(echo $LAST_VERSION | awk -F. -v K=$PATCH_COLUMN '{$K+=1; print $0}' OFS='.')
+
+echo "Bumped to new candidate version: $BUMPED_VERSION"
+
+RC_VERSION=${BUMPED_VERSION}rc${RC_DATE}
+
+echo "Final RC version: $RC_VERSION"
+
+
+###################
+# CHANGELOG ENTRY #
+###################
+
+CHANGE_DIFF_TARGETS="v${LAST_VERSION}..HEAD"
+TMP_CHANGE_LOG="./rc-${RC_DATE}.txt"
+
+VERSION_TITLE="${RC_VERSION} (__rc__)"
+TITLE_LINE=$(awk -v LL=${#VERSION_TITLE} 'BEGIN{for(c=0;c<LL;c++) printf "-"}')
+VERSION_HEADER="$VERSION_TITLE\n${TITLE_LINE}"
+
+# VERSION HEADER:
+echo -e "$VERSION_HEADER\n" >> $TMP_CHANGE_LOG
+
+# COLLECT ALL COMMITS:
+git log --pretty=oneline --abbrev-commit $CHANGE_DIFF_TARGETS | sed 's/^/- /' >> $TMP_CHANGE_LOG
+
+# CHECK FINAL CONTENT
+cat $TMP_CHANGE_LOG
+CHANGE_LOG_CONTENTS=$(cat $TMP_CHANGE_LOG)
+
+# APPEND INFO TO CHANGE FILE:
+
+# FIXME: needs fixing here!
+# https://stackoverflow.com/questions/9970124/sed-to-insert-on-first-match-only
+# maybe use awk for portability
+
+sed -i '' '/^[0-9]+\.0\.0.*\(tbd\)/a\
+yo
+' $CHANGE_FILE

--- a/bin/update_changelog.sh
+++ b/bin/update_changelog.sh
@@ -73,6 +73,9 @@ VERSION_TITLE="${RC_VERSION} (__rc__)"
 TITLE_LINE=$(awk -v LL=${#VERSION_TITLE} 'BEGIN{for(c=0;c<LL;c++) printf "-"}')
 VERSION_HEADER="$VERSION_TITLE\n${TITLE_LINE}"
 
+# DEBUG INFO
+echo -e "Comparing versions between: $CHANGE_DIFF_TARGETS\n"
+
 # VERSION HEADER:
 echo -e "$VERSION_HEADER\n" >> $TMP_CHANGE_LOG
 

--- a/bin/update_changelog.sh
+++ b/bin/update_changelog.sh
@@ -10,6 +10,19 @@
 
 CHANGE_FILE='CHANGES.rst'
 RC_DATE=$(date +'%m-%d-%Y')
+TMP_CHANGE_LOG="./rc-${RC_DATE}.txt"
+
+
+############
+# CLEANUPS #
+############
+
+rm -rf $TMP_CHANGE_LOG
+
+
+##################
+# INITIALIZATION #
+##################
 
 echo "Updating $CHANGE_FILE:"
 
@@ -41,8 +54,6 @@ echo "Final RC version: $RC_VERSION"
 ###################
 
 CHANGE_DIFF_TARGETS="v${LAST_VERSION}..HEAD"
-TMP_CHANGE_LOG="./rc-${RC_DATE}.txt"
-
 VERSION_TITLE="${RC_VERSION} (__rc__)"
 TITLE_LINE=$(awk -v LL=${#VERSION_TITLE} 'BEGIN{for(c=0;c<LL;c++) printf "-"}')
 VERSION_HEADER="$VERSION_TITLE\n${TITLE_LINE}"
@@ -55,14 +66,14 @@ git log --pretty=oneline --abbrev-commit $CHANGE_DIFF_TARGETS | sed 's/^/- /' >>
 
 # CHECK FINAL CONTENT
 cat $TMP_CHANGE_LOG
-CHANGE_LOG_CONTENTS=$(cat $TMP_CHANGE_LOG)
 
 # APPEND INFO TO CHANGE FILE:
+#   1. Finds the first (tbd) release
+#   2. Populates space between (tbd) release with RC changes
+sed -i '' "/^[0-9]\.0\.0.*\(tbd\)/{N;G;r\
+\
+$TMP_CHANGE_LOG
+\
+}" $CHANGE_FILE
 
-# FIXME: needs fixing here!
-# https://stackoverflow.com/questions/9970124/sed-to-insert-on-first-match-only
-# maybe use awk for portability
-
-sed -i '' '/^[0-9]+\.0\.0.*\(tbd\)/a\
-yo
-' $CHANGE_FILE
+# CHANGE_LOG_CONTENTS=$(cat $TMP_CHANGE_LOG)

--- a/bin/update_changelog.sh
+++ b/bin/update_changelog.sh
@@ -14,7 +14,7 @@ set -e # exit on errors
 
 CHANGE_FILE='CHANGES.rst'
 RC_DATE=$(date +'%m-%d-%Y')
-WORKSPACE_DIR=${GITHUB_WORKSPACE:-.}
+WORKSPACE_DIR="${GITHUB_WORKSPACE:-.}/rc"
 TMP_CHANGE_LOG="${WORKSPACE_DIR}/rc-${RC_DATE}.txt"
 
 
@@ -23,6 +23,7 @@ TMP_CHANGE_LOG="${WORKSPACE_DIR}/rc-${RC_DATE}.txt"
 ############
 
 rm -rf $TMP_CHANGE_LOG
+mkdir -p $WORKSPACE_DIR
 
 
 ##################
@@ -70,6 +71,7 @@ echo -e "$VERSION_HEADER\n" >> $TMP_CHANGE_LOG
 git log --pretty=oneline --abbrev-commit $CHANGE_DIFF_TARGETS | sed 's/^/- /' >> $TMP_CHANGE_LOG
 
 # CHECK FINAL CONTENT
+ls $WORKSPACE_DIR
 cat $TMP_CHANGE_LOG
 
 # APPEND INFO TO CHANGE FILE:


### PR DESCRIPTION
> Related to #405.  
> This is still a work in progress and is likely to change ⚠️ 

# General idea

To save the time required for creating RC's manually, I'm thinking of delegating this task to GH actions!  
(This should allow me some spare time :D, but also should make the release process more transparent and, hopefully, increase the release frequency) 

## How?

Current vision:

1. GH Action `new-rc` will collect all the change information since the latest release.
2. GH Action will prepare an entry in the `CHANGES.rst` under a new _patch_ release candidate.
3. GH Action creates a new branch and a pull request from this branch to the `main` 
4. Maintainers review the proposed release and changes, make manual changes (e.g. to the CHANGES.rst) as necessary, and push upstream
5. Once it's ready, the RC pull request is merged to `main` creating a new tag.
6. When this tag ends up on the `main`, a new release pipeline is triggered causing all builds and pushes to PyPi and docker hub. 

### Current progress

For now, I'm only in the beginning phase of getting this ready. For live updates, keep an eye on this PR!

### Action points

- [x] Setup a `release_candidate` github workflow
- [x] Detect the change log entries automatically
- [x] Update the change log from the action
- [x] Open a new _draft_ release candidate PR for the review   

### Feedback

Any feedback and suggestions are very welcome. It's, I have to be honest, the first time I'm setting this up here ✌️ 