### PR TITLE
fix(setuptools-in-tests): add `packages=[]` in test setup

### DIFF
--- a/requirements/test.pip
+++ b/requirements/test.pip
@@ -7,7 +7,7 @@ pip
 passlib>=1.6
 pytest>=6.2.2
 pytest-cov
-setuptools
+setuptools>=40.0,<62.0.0
 tox
 twine
 webtest

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -119,6 +119,7 @@ setup(
     options={
         "bdist_wheel": {"universal": True},
     },
+    packages=[],
 )
 """
 


### PR DESCRIPTION
# What

Fixing test setup to overcome https://github.com/pypa/setuptools/issues/3197 
 