### PR TITLE
Replace usage of deprecated inspect.getargspec

### DIFF
--- a/pypiserver/bottle.py
+++ b/pypiserver/bottle.py
@@ -41,7 +41,6 @@ import base64, cgi, email.utils, functools, hmac, itertools, mimetypes,\
 from datetime import date as datedate, datetime, timedelta
 from tempfile import TemporaryFile
 from traceback import format_exc, print_exc
-from inspect import getargspec
 from unicodedata import normalize
 
 
@@ -79,6 +78,7 @@ except IOError:
 # Lots of stdlib and builtin differences.
 if py3k:
     import http.client as httplib
+    from inspect import getfullargspec as getargspec
     import _thread as thread
     from urllib.parse import urljoin, SplitResult as UrlSplitResult
     from urllib.parse import urlencode, quote as urlquote, unquote as urlunquote
@@ -101,6 +101,7 @@ if py3k:
     def _raise(*a): raise a[0](a[1]).with_traceback(a[2])
 else: # 2.x
     import httplib
+    from inspect import getargspec
     import thread
     from urlparse import urljoin, SplitResult as UrlSplitResult
     from urllib import urlencode, quote as urlquote, unquote as urlunquote


### PR DESCRIPTION
Use `getfullargspec` for Python 3.x to support Python 3.11 where `getargspec` was removed complete.