### PR TITLE
feat: :stethoscope: allow customized health check endpoint

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -920,8 +920,8 @@ Further information on micropython-packaging can be found here: https://docs.mic
 Custom Health Check Endpoint
 ----------------------------
 
-pypiserver provide a default health endpoint. ``/health`` It always returns
-``200 Ok`` if the service is up. Otherwise it means that the service is dead.
+``pypiserver`` provides a default health endpoint at ``/health``. It always returns
+``200 Ok`` if the service is up. Otherwise, it means that the service is not responsive.
 
 pypiserver also allow users to customize the health endpoint. (see `#441 <https://github.com/pypiserver/pypiserver/issues/441>`_).
 Alphanumeric characters, hyphens, forward slashes and underscores are allowed.

--- a/README.rst
+++ b/README.rst
@@ -945,7 +945,7 @@ Configure a custom health endpoint by script
     app = pypiserver.app(root="./packages", health_endpoint="/action/health")
     bottle.run(app=app, host="0.0.0.0", port=8080, server="auto")
 
-Try `curl http://localhost:8080/action/health`
+Try ``curl http://localhost:8080/action/health``
 
 
 Sources

--- a/README.rst
+++ b/README.rst
@@ -135,6 +135,10 @@ not officially supported, and will not receive bugfixes or new features.
         For packages not found in the local index, this URL will be used to
         redirect to (default: https://pypi.org/simple/).
 
+      --health-endpoint HEALTH_ENDPOINT
+        Configure a custom liveness endpoint. It always returns 200 Ok if 
+        the service is up. Otherwise it means that the service is dead.
+
       --server METHOD
         Use METHOD to run the server. Valid values include paste,
         cherrypy, twisted, gunicorn, gevent, wsgiref, auto. The

--- a/README.rst
+++ b/README.rst
@@ -920,18 +920,17 @@ Further information on micropython-packaging can be found here: https://docs.mic
 Custom Health Check Endpoint
 ----------------------------
 
-pypiserver provide a default health endpoint. `/health`
-It always returns 200 Ok if the service is up. Otherwise it means that the 
-service is dead.
+pypiserver provide a default health endpoint. ``/health`` It always returns
+``200 Ok`` if the service is up. Otherwise it means that the service is dead.
 
 pypiserver also allow users to customize the health endpoint. (see `#441 <https://github.com/pypiserver/pypiserver/issues/441>`_).
 Alphanumeric characters, hyphens, forward slashes and underscores are allowed.
-Such as: `/healthz`, `/health/live-1`, `/api_health`, `/action/health`
+Valid example: `/healthz`, `/health/live-1`, `/api_health`, `/action/health`
 
 Configure a custom health endpoint by CLI arguments
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Run pypiserver with argument::
+Run pypiserver with ``--health-endpoint`` argument::
 
     pypi-server --health-endpoint /action/health
 

--- a/README.rst
+++ b/README.rst
@@ -917,6 +917,36 @@ Installing packages from the REPL of an embedded device works in this way:
 
 Further information on micropython-packaging can be found here: https://docs.micropython.org/en/latest/reference/packages.html
 
+Custom Health Check Endpoint
+----------------------------
+
+pypiserver provide a default health endpoint. `/health`
+It always returns 200 Ok if the service is up. Otherwise it means that the 
+service is dead.
+
+pypiserver also allow users to customize the health endpoint. (see `#441 <https://github.com/pypiserver/pypiserver/issues/441>`_).
+Alphanumeric characters, hyphens, forward slashes and underscores are allowed.
+Such as: `/healthz`, `/health/live-1`, `/api_health`, `/action/health`
+
+Configure a custom health endpoint by CLI arguments
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Run pypiserver with argument::
+
+    pypi-server --health-endpoint /action/health
+
+Configure a custom health endpoint by script
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. code-block:: python
+
+    import pypiserver
+    from pypiserver import bottle
+    app = pypiserver.app(root="./packages", health_endpoint="/action/health")
+    bottle.run(app=app, host="0.0.0.0", port=8080, server="auto")
+
+Try `curl http://localhost:8080/action/health`
+
 
 Sources
 =======

--- a/README.rst
+++ b/README.rst
@@ -136,8 +136,8 @@ not officially supported, and will not receive bugfixes or new features.
         redirect to (default: https://pypi.org/simple/).
 
       --health-endpoint HEALTH_ENDPOINT
-        Configure a custom liveness endpoint. It always returns 200 Ok if 
-        the service is up. Otherwise it means that the service is dead.
+        Configure a custom liveness endpoint. It always returns 200 Ok if  
+        the service is up. Otherwise, it means that the service is not responsive.
 
       --server METHOD
         Use METHOD to run the server. Valid values include paste,

--- a/README.rst
+++ b/README.rst
@@ -923,9 +923,10 @@ Custom Health Check Endpoint
 ``pypiserver`` provides a default health endpoint at ``/health``. It always returns
 ``200 Ok`` if the service is up. Otherwise, it means that the service is not responsive.
 
-pypiserver also allow users to customize the health endpoint. (see `#441 <https://github.com/pypiserver/pypiserver/issues/441>`_).
-Alphanumeric characters, hyphens, forward slashes and underscores are allowed.
-Valid example: `/healthz`, `/health/live-1`, `/api_health`, `/action/health`
+In addition, ``pypiserver`` allows users to customize the health endpoint.
+Alphanumeric characters, hyphens, forward slashes and underscores are allowed
+and the endpoint should not overlap with any existing routes.
+Valid examples: ``/healthz``, ``/health/live-1``, ``/api_health``, ``/action/health``
 
 Configure a custom health endpoint by CLI arguments
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/pypiserver/__init__.py
+++ b/pypiserver/__init__.py
@@ -147,11 +147,20 @@ def app_from_config(config: RunConfig) -> Bottle:
     # Add a reference to our config on the Bottle app for easy access in testing
     # and other contexts.
     _app.app._pypiserver_config = config
-    # add customized health check endpoint
-    _app.app.route(_get_health_endpoint(config, _app.app), "GET", lambda: "Ok")
     return _app.app
 
 
+def setup_routes_from_config(app: Bottle, config: RunConfig) -> Bottle:
+    """Set up additional routes supplied from the config."""
+    def _setup_health_endpoint(app, config):
+        if config.health_endpoint in [route.rule for route in app.routes]:
+            raise RuntimeError(
+                "Provided health endpoint overlaps with existing routes"
+            )
+        app.route(config.health_endpoint, "GET", lambda: "Ok")
+
+    _setup_health_endpoint(app, config)
+    return app
 T = t.TypeVar("T")
 
 

--- a/pypiserver/__init__.py
+++ b/pypiserver/__init__.py
@@ -143,6 +143,7 @@ def app_from_config(config: RunConfig) -> Bottle:
 
 def setup_routes_from_config(app: Bottle, config: RunConfig) -> Bottle:
     """Set up additional routes supplied from the config."""
+
     def _setup_health_endpoint(app, config):
         if config.health_endpoint in [route.rule for route in app.routes]:
             raise RuntimeError(

--- a/pypiserver/__init__.py
+++ b/pypiserver/__init__.py
@@ -5,7 +5,7 @@ import sys
 import typing as t
 
 from pypiserver.bottle import Bottle
-from pypiserver.config import DEFAULTS, Config, RunConfig, strtobool
+from pypiserver.config import Config, RunConfig, strtobool
 
 version = __version__ = "1.5.0"
 __version_info__ = tuple(_re.split("[.-]", __version__))

--- a/pypiserver/__init__.py
+++ b/pypiserver/__init__.py
@@ -114,15 +114,6 @@ def backwards_compat_kwargs(kwargs: dict, warn: bool = True) -> dict:
     return updated_kwargs
 
 
-def _get_health_endpoint(config: RunConfig, app: Bottle) -> str:
-    """Verify the health_endpoint and fallback to default if invalid."""
-    # Avoid health check route uses exist endpoints
-    for rule in (route.rule for route in app.routes if route.rule != "/"):
-        if config.health_endpoint.startswith(rule):
-            return DEFAULTS.HEALTH_ENDPOINT
-    return config.health_endpoint
-
-
 def app(**kwargs: t.Any) -> Bottle:
     """Construct a bottle app running pypiserver.
 
@@ -130,7 +121,7 @@ def app(**kwargs: t.Any) -> Bottle:
         (or its base), defined in `pypiserver.config`, may be overridden.
     """
     config = Config.default_with_overrides(**backwards_compat_kwargs(kwargs))
-    return app_from_config(config)
+    return setup_routes_from_config(app_from_config(config), config)
 
 
 def app_from_config(config: RunConfig) -> Bottle:
@@ -161,6 +152,8 @@ def setup_routes_from_config(app: Bottle, config: RunConfig) -> Bottle:
 
     _setup_health_endpoint(app, config)
     return app
+
+
 T = t.TypeVar("T")
 
 

--- a/pypiserver/__main__.py
+++ b/pypiserver/__main__.py
@@ -169,6 +169,7 @@ def main(argv: t.Sequence[str] = None) -> None:
     # Here `app` is a Bottle instance, which we pass to bottle.run() to run
     # the server
     app = pypiserver.app_from_config(config)
+    app = pypiserver.setup_routes_from_config(app, config)
 
     if config.server_method == "gunicorn":
         # When bottle runs gunicorn, gunicorn tries to pull its arguments from

--- a/pypiserver/_app.py
+++ b/pypiserver/_app.py
@@ -109,8 +109,8 @@ def get_health_endpoint():
 
 @app.route(get_health_endpoint())
 def health():
-    """ This endpoint should always response 200 OK,
-        otherwise means that the service is unhealthy or dead. """
+    """This endpoint should always response 200 OK,
+    otherwise means that the service is unhealthy or dead."""
     return "Ok"
 
 

--- a/pypiserver/_app.py
+++ b/pypiserver/_app.py
@@ -82,6 +82,11 @@ def log_error(http_error):
     log.info(config.log_err_frmt, vars(http_error))
 
 
+@app.route("/health")
+def health():
+    return "Ok"
+
+
 @app.route("/favicon.ico")
 def favicon():
     return HTTPError(404)

--- a/pypiserver/_app.py
+++ b/pypiserver/_app.py
@@ -82,38 +82,6 @@ def log_error(http_error):
     log.info(config.log_err_frmt, vars(http_error))
 
 
-_health_check_endpoint_re = re.compile(r"^/[a-z0-9/_-]+$", re.I)
-
-
-def is_valid_health_check_endpoint(endpoint: str) -> bool:
-    # Avoid health check route uses reserved endpoints
-    invalid_prefixes = ["/simple", "/packages", "/RPC2"]
-    for prefix in invalid_prefixes:
-        if endpoint.startswith(prefix):
-            return False
-    return _health_check_endpoint_re.fullmatch(endpoint) is not None
-
-
-def get_health_endpoint():
-    """ Get the liveness endpoint from the environment variable
-         `HEALTH_ENDPOINT` and verify it.
-        If the customized endpoint is invalied, it will fallback to the
-         DEFAULT_HEALTH_ENDPOINT. """
-
-    DEFAULT_HEALTH_ENDPOINT = "/health"
-    customized_endpoint = os.environ.get("HEALTH_ENDPOINT", DEFAULT_HEALTH_ENDPOINT)
-    if not is_valid_health_check_endpoint(customized_endpoint):
-        return DEFAULT_HEALTH_ENDPOINT
-    return customized_endpoint
-
-
-@app.route(get_health_endpoint())
-def health():
-    """This endpoint should always response 200 OK,
-    otherwise means that the service is unhealthy or dead."""
-    return "Ok"
-
-
 @app.route("/favicon.ico")
 def favicon():
     return HTTPError(404)

--- a/pypiserver/config.py
+++ b/pypiserver/config.py
@@ -402,7 +402,7 @@ def get_parser() -> argparse.ArgumentParser:
         type=health_endpoint_arg,
         help=(
             "Configure a custom liveness endpoint. It always returns 200 Ok if "
-            "the service is up. Otherwise it means that the service is dead."
+            "the service is up. Otherwise, it means that the service is not responsive."
         ),
     )
     run_parser.add_argument(

--- a/pypiserver/config.py
+++ b/pypiserver/config.py
@@ -396,8 +396,8 @@ def get_parser() -> argparse.ArgumentParser:
         default=DEFAULTS.HEALTH_ENDPOINT,
         type=health_endpoint_arg,
         help=(
-            "The liveness endpoint. Always response 200 OK, otherwise means"
-            "that the service is unhealthy or dead."
+            "Configure a custom liveness endpoint. It always returns 200 OK if the service is up." 
+            "Otherwise it means that the service is unhealthy or dead."
         ),
     )
     run_parser.add_argument(

--- a/pypiserver/config.py
+++ b/pypiserver/config.py
@@ -143,7 +143,7 @@ def health_endpoint_arg(arg: str) -> str:
 
     raise argparse.ArgumentTypeError(
         "Invalid path for the health endpoint. Make sure that it contains only "
-        "alphanumeric characters, hyphens, forward slashes and underscores."
+        "alphanumeric characters, hyphens, forward slashes and underscores. "
         f"In other words, make sure to match the following regex: {rule_regex}"
     )
 

--- a/pypiserver/config.py
+++ b/pypiserver/config.py
@@ -48,12 +48,12 @@ from distutils.util import strtobool as strtoint
 import pkg_resources
 
 from pypiserver.backend import (
-    SimpleFileBackend,
-    CachingFileBackend,
     Backend,
-    IBackend,
-    get_file_backend,
     BackendProxy,
+    CachingFileBackend,
+    IBackend,
+    SimpleFileBackend,
+    get_file_backend,
 )
 
 # The `passlib` requirement is optional, so we need to verify its import here.
@@ -396,8 +396,8 @@ def get_parser() -> argparse.ArgumentParser:
         default=DEFAULTS.HEALTH_ENDPOINT,
         type=health_endpoint_arg,
         help=(
-            "Configure a custom liveness endpoint. It always returns 200 OK if the service is up." 
-            "Otherwise it means that the service is unhealthy or dead."
+            "Configure a custom liveness endpoint. It always returns 200 Ok if "
+            "the service is up. Otherwise it means that the service is dead."
         ),
     )
     run_parser.add_argument(

--- a/pypiserver/config.py
+++ b/pypiserver/config.py
@@ -48,12 +48,12 @@ from distutils.util import strtobool as strtoint
 import pkg_resources
 
 from pypiserver.backend import (
-    Backend,
-    BackendProxy,
-    CachingFileBackend,
-    IBackend,
     SimpleFileBackend,
+    CachingFileBackend,
+    Backend,
+    IBackend,
     get_file_backend,
+    BackendProxy,
 )
 
 # The `passlib` requirement is optional, so we need to verify its import here.

--- a/pypiserver/config.py
+++ b/pypiserver/config.py
@@ -136,11 +136,16 @@ def hash_algo_arg(arg: str) -> t.Optional[str]:
 
 
 def health_endpoint_arg(arg: str) -> str:
-    """Verify the health_endpoint and fallback to default if invalid."""
-    # Only allow alphanumeric, hyphen, forward slash, and underscore
-    if re.fullmatch(r"^/[a-z0-9/_-]+$", arg, re.I) is None:
-        return DEFAULTS.HEALTH_ENDPOINT
-    return arg
+    """Verify the health_endpoint and raises ValueError if invalid."""
+    rule_regex = r"^/[a-z0-9/_-]+$"
+    if re.fullmatch(rule_regex, arg, re.I) is not None:
+        return arg
+
+    raise argparse.ArgumentTypeError(
+        "Invalid path for the health endpoint. Make sure that it contains only "
+        "alphanumeric characters, hyphens, forward slashes and underscores."
+        f"In other words, make sure to match the following regex: {rule_regex}"
+    )
 
 
 def html_file_arg(arg: t.Optional[str]) -> str:

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -197,7 +197,9 @@ def test_health_default_endpoint(testapp):
 def test_health_customized_endpoint(root):
     from pypiserver import app
 
-    testapp = webtest.TestApp(app(root=root.strpath, health_endpoint="/healthz"))
+    testapp = webtest.TestApp(
+        app(root=root.strpath, health_endpoint="/healthz")
+    )
     resp = testapp.get("/healthz")
     assert resp.status_int == 200
     assert "Ok" in resp

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -41,22 +41,6 @@ def testapp(app):
     return webtest.TestApp(app)
 
 
-def testapp_with_env(tmpdir):
-    """Similar to testapp but with environment
-    please monkeypatch environment variable before create testapp."""
-    from pypiserver import app
-
-    bottle.debug(True)
-    return webtest.TestApp(
-        app(
-            roots=[pathlib.Path(tmpdir.strpath)],
-            authenticate=[],
-            password_file=".",
-            backend_arg="simple-dir",
-        )
-    )
-
-
 @pytest.fixture
 def root(tmpdir):
     """Return a pytest temporary directory"""
@@ -210,19 +194,19 @@ def test_health_default_endpoint(testapp):
     assert "Ok" in resp
 
 
-def test_health_customized_endpoint(monkeypatch, tmpdir):
-    monkeypatch.setenv("HEALTH_ENDPOINT", "/healthz")
-    testapp = testapp_with_env(tmpdir)
+def test_health_customized_endpoint(root):
+    from pypiserver import app
 
+    testapp = webtest.TestApp(app(root=root.strpath, health_endpoint="/healthz"))
     resp = testapp.get("/healthz")
     assert resp.status_int == 200
     assert "Ok" in resp
 
 
-def test_health_invalid_customized_endpoint(monkeypatch, tmpdir):
-    monkeypatch.setenv("HEALTH_ENDPOINT", "/:health")
-    testapp = testapp_with_env(tmpdir)
+def test_health_invalid_customized_endpoint(root):
+    from pypiserver import app
 
+    testapp = webtest.TestApp(app(root=root.strpath, health_endpoint="/simple"))
     resp = testapp.get("/health")
     assert resp.status_int == 200
     assert "Ok" in resp

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -207,11 +207,8 @@ def test_health_customized_endpoint(root):
 def test_health_invalid_customized_endpoint(root):
     from pypiserver import app
 
-    _app = app(root=root.strpath, health_endpoint="/simple")
-    testapp = webtest.TestApp(_app)
-    resp = testapp.get("/health")
-    assert resp.status_int == 200
-    assert "Ok" in resp
+    with pytest.raises(RuntimeError, match="overlaps with existing routes"):
+        app(root=root.strpath, health_endpoint="/simple")
 
 
 def test_favicon(testapp):

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -188,6 +188,12 @@ def test_packages_empty(testapp):
     assert len(resp.html("a")) == 0
 
 
+def test_health(testapp):
+    resp = testapp.get("/health")
+    assert resp.status_int == 200
+    assert "Ok" in resp
+
+
 def test_favicon(testapp):
     testapp.get("/favicon.ico", status=404)
 

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -197,9 +197,8 @@ def test_health_default_endpoint(testapp):
 def test_health_customized_endpoint(root):
     from pypiserver import app
 
-    testapp = webtest.TestApp(
-        app(root=root.strpath, health_endpoint="/healthz")
-    )
+    _app = app(root=root.strpath, health_endpoint="/healthz")
+    testapp = webtest.TestApp(_app)
     resp = testapp.get("/healthz")
     assert resp.status_int == 200
     assert "Ok" in resp

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -207,7 +207,8 @@ def test_health_customized_endpoint(root):
 def test_health_invalid_customized_endpoint(root):
     from pypiserver import app
 
-    testapp = webtest.TestApp(app(root=root.strpath, health_endpoint="/simple"))
+    _app = app(root=root.strpath, health_endpoint="/simple")
+    testapp = webtest.TestApp(_app)
     resp = testapp.get("/health")
     assert resp.status_int == 200
     assert "Ok" in resp

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -42,8 +42,8 @@ def testapp(app):
 
 
 def testapp_with_env(tmpdir):
-    """ Similar to testapp but with environment
-        please monkeypatch environment variable before create testapp. """
+    """Similar to testapp but with environment
+    please monkeypatch environment variable before create testapp."""
     from pypiserver import app
 
     bottle.debug(True)

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -369,6 +369,28 @@ _CONFIG_TEST_PARAMS: t.Tuple[ConfigTestCase, ...] = (
         exp_config_type=RunConfig,
         exp_config_values={"fallback_url": "foobar.com"},
     ),
+    # health-endpoint
+    ConfigTestCase(
+        case="Run: health-endpoint unspecified",
+        args=["run"],
+        legacy_args=[],
+        exp_config_type=RunConfig,
+        exp_config_values={"health_endpoint": DEFAULTS.HEALTH_ENDPOINT},
+    ),
+    ConfigTestCase(
+        case="Run: health-endpoint specified",
+        args=["run", "--health-endpoint", "/healthz"],
+        legacy_args=["--health-endpoint", "/healthz"],
+        exp_config_type=RunConfig,
+        exp_config_values={"health_endpoint": "/healthz"},
+    ),
+    ConfigTestCase(
+        case="Run: health-endpoint specified but invalid",
+        args=["run", "--health-endpoint", "/health!"],
+        legacy_args=["--health-endpoint", "/health!"],
+        exp_config_type=RunConfig,
+        exp_config_values={"health_endpoint": DEFAULTS.HEALTH_ENDPOINT},
+    ),
     # server method
     ConfigTestCase(
         case="Run: server method unspecified",

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -705,6 +705,14 @@ _CONFIG_ERROR_CASES = (
         )
         for val in ("true", "foo", "1", "md6")
     ),
+    *(
+        ConfigErrorCase(
+            case=f"Invalid health endpoint: {val}",
+            args=["run", "--health-endpoint", val],
+            exp_txt="Invalid path for the health endpoint",
+        )
+        for val in ("/", "health", "/health!", "/:health", "/health?check=True")
+    ),
 )
 # pylint: disable=unsubscriptable-object
 CONFIG_ERROR_PARAMS = (i[1:] for i in _CONFIG_ERROR_CASES)

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -384,13 +384,6 @@ _CONFIG_TEST_PARAMS: t.Tuple[ConfigTestCase, ...] = (
         exp_config_type=RunConfig,
         exp_config_values={"health_endpoint": "/healthz"},
     ),
-    ConfigTestCase(
-        case="Run: health-endpoint specified but invalid",
-        args=["run", "--health-endpoint", "/health!"],
-        legacy_args=["--health-endpoint", "/health!"],
-        exp_config_type=RunConfig,
-        exp_config_values={"health_endpoint": DEFAULTS.HEALTH_ENDPOINT},
-    ),
     # server method
     ConfigTestCase(
         case="Run: server method unspecified",

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -747,7 +747,7 @@ def test_config(
 @pytest.mark.parametrize(
     "args, exp_txt",
     CONFIG_ERROR_PARAMS,
-    ids=CONFIG_TEST_IDS,
+    ids=CONFIG_ERROR_IDS,
 )
 def test_config_error(
     args: t.List[str],

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -12,6 +12,7 @@ import pytest
 
 # Local imports
 import pypiserver
+from pypiserver.config import Config
 
 logger = logging.getLogger(__name__)
 
@@ -103,3 +104,19 @@ def test_backwards_compat_kwargs_duplicate_check(
     with pytest.raises(ValueError) as err:
         pypiserver.backwards_compat_kwargs(kwargs)
     assert "('redirect_to_fallback', 'disable_fallback')" in str(err.value)
+
+
+def test_setup_routes_from_config_customized_endpoint():
+    _app = pypiserver.setup_routes_from_config(
+        pypiserver.app(),
+        Config.default_with_overrides(health_endpoint="/healthz"),
+    )
+    assert "/healthz" in (route.rule for route in _app.routes)
+
+
+def test_setup_routes_from_config_invalid_customized_endpoint():
+    with pytest.raises(RuntimeError, match="overlaps with existing routes"):
+        pypiserver.setup_routes_from_config(
+            pypiserver.app(),
+            Config.default_with_overrides(health_endpoint="/simple"),
+        )

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -106,7 +106,7 @@ def test_backwards_compat_kwargs_duplicate_check(
     assert "('redirect_to_fallback', 'disable_fallback')" in str(err.value)
 
 
-def test_setup_routes_from_config_customized_endpoint():
+def test_setup_routes_from_config_customized_endpoint() -> None:
     _app = pypiserver.setup_routes_from_config(
         pypiserver.app(),
         Config.default_with_overrides(health_endpoint="/healthz"),
@@ -114,7 +114,7 @@ def test_setup_routes_from_config_customized_endpoint():
     assert "/healthz" in (route.rule for route in _app.routes)
 
 
-def test_setup_routes_from_config_invalid_customized_endpoint():
+def test_setup_routes_from_config_invalid_customized_endpoint() -> None:
     with pytest.raises(RuntimeError, match="overlaps with existing routes"):
         pypiserver.setup_routes_from_config(
             pypiserver.app(),

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -294,3 +294,20 @@ def test_auto_servers() -> None:
         us.name.lower() in them
         for us, them in zip(our_check_order, bottle_adapters)
     )
+
+
+def test_health_endpoint_default(main):
+    main([])
+    assert main.app._pypiserver_config.health_endpoint == "/health"
+    assert "/health" in (route.rule for route in main.app.routes)
+
+
+def test_health_endpoint_customized(main):
+    main(["--health-endpoint", "/healthz"])
+    assert main.app._pypiserver_config.health_endpoint == "/healthz"
+    assert "/healthz" in (route.rule for route in main.app.routes)
+
+
+def test_health_endpoint_invalid_customized(main):
+    with pytest.raises(SystemExit):
+        main(["--health-endpoint", "/health!"])


### PR DESCRIPTION
~~Get the liveness endpoint from the environment variable `HEALTH_ENDPOINT` and verify it. If the customized endpoint is invalied, it will fallback to the DEFAULT_HEALTH_ENDPOINT.~~

UPDATE 2022-10-21
----------------------------

`pypiserver` provides a default health endpoint at `/health`. It always returns
`200 Ok` if the service is up. Otherwise, it means that the service is not responsive.

In addition, `pypiserver` allows users to customize the health endpoint.

Alphanumeric characters, hyphens, forward slashes and underscores are allowed and the endpoint should not overlap with any existing routes.

Valid examples: `/healthz`, `/health/live-1`, `/api_health`, `/action/health`