### PR TITLE
fix: docker tests in cicd

### DIFF
--- a/docker/docker-requirements.txt
+++ b/docker/docker-requirements.txt
@@ -1,6 +1,6 @@
 # We use gunicorn as the default server in the docker container, with gevent
 # workers
-gevent==21.1.2
+gevent==21.12.0
 gunicorn==20.0.4
 passlib==1.7.4
 bcrypt==3.2.0

--- a/docker/test_docker.py
+++ b/docker/test_docker.py
@@ -16,6 +16,9 @@ import pypiserver
 import pytest
 
 
+PYPISERVER_PROCESS_NAME = "pypi-server"
+TEST_DEMO_PIP_PACKAGE = "pypiserver-mypkg"
+
 THIS_DIR = Path(__file__).parent
 ROOT_DIR = THIS_DIR.parent
 DOCKERFILE = ROOT_DIR / "Dockerfile"
@@ -24,13 +27,13 @@ MYPKG_ROOT = FIXTURES / "mypkg"
 HTPASS_FILE = FIXTURES / "htpasswd.a.a"
 
 
-# This is largely useless when using pytest because of the need to use the name
-# of the fixture as an argument to the test function or fixture using it
+# This rule is largely useless when using pytest because of the need to use the
+# name of the fixture as an argument to the test function or fixture using it
 # pylint: disable=redefined-outer-name
 #
-# Also useless for our test context, where we may want to group test functions
-# in a class to share common fixtures, but where we don't care about the
-# `self` instance.
+# Also useless rule for our test context, where we may want to group test
+# functions in a class to share common fixtures, but where we don't care about
+# the `self` instance.
 # pylint: disable=no-self-use
 
 
@@ -144,9 +147,9 @@ def uninstall_pkgs() -> None:
     """Uninstall any packages we've installed."""
     res = run("pip", "freeze", capture=True)
     if any(
-        ln.strip().startswith("pypiserver-mypkg") for ln in res.out.splitlines()
+        ln.strip().startswith(TEST_DEMO_PIP_PACKAGE) for ln in res.out.splitlines()
     ):
-        run("pip", "uninstall", "-y", "pypiserver-mypkg")
+        run("pip", "uninstall", "-y", TEST_DEMO_PIP_PACKAGE)
 
 
 @pytest.fixture(scope="session", autouse=True)
@@ -169,7 +172,7 @@ class TestCommands:
     def test_help(self, image: str) -> None:
         """We can get help from the docker container."""
         res = run("docker", "run", image, "--help", capture=True)
-        assert "pypi-server" in res.out
+        assert PYPISERVER_PROCESS_NAME in res.out
 
     def test_version(self, image: str) -> None:
         """We can get the version from the docker container."""
@@ -267,7 +270,7 @@ class TestPermissions:
             proc_line = next(
                 filter(
                     # grab the process line for the pypi-server process
-                    lambda ln: "pypi-server" in ln,
+                    lambda ln: PYPISERVER_PROCESS_NAME in ln,
                     res.out.splitlines(),
                 )
             )
@@ -394,7 +397,7 @@ class TestBasics:
             "install",
             "--index-url",
             f"http://localhost:{container.port}/simple",
-            "pypiserver-mypkg",
+            TEST_DEMO_PIP_PACKAGE,
         )
         run("python", "-c", "'import pypiserver_mypkg; mypkg.pkg_name()'")
 
@@ -560,7 +563,7 @@ class TestAuthed:
             "install",
             "--index-url",
             f"http://a:a@localhost:{self.HOST_PORT}/simple",
-            "pypiserver-mypkg",
+            TEST_DEMO_PIP_PACKAGE,
         )
         run("python", "-c", "'import pypiserver_mypkg; mypkg.pkg_name()'")
 
@@ -580,7 +583,7 @@ class TestAuthed:
             "--no-cache",
             "--index-url",
             f"http://localhost:{self.HOST_PORT}/simple",
-            "pypiserver-mypkg",
+            TEST_DEMO_PIP_PACKAGE,
             check_code=lambda c: c != 0,
         )
 

--- a/docker/test_docker.py
+++ b/docker/test_docker.py
@@ -147,7 +147,8 @@ def uninstall_pkgs() -> None:
     """Uninstall any packages we've installed."""
     res = run("pip", "freeze", capture=True)
     if any(
-        ln.strip().startswith(TEST_DEMO_PIP_PACKAGE) for ln in res.out.splitlines()
+        ln.strip().startswith(TEST_DEMO_PIP_PACKAGE)
+        for ln in res.out.splitlines()
     ):
         run("pip", "uninstall", "-y", TEST_DEMO_PIP_PACKAGE)
 
@@ -333,7 +334,7 @@ class TestBasics:
             ".",
             "--authenticate",
             ".",
-            *request.param,  # type: ignore
+            *request.param,
         )
         res = run(*args, capture=True)
         wait_for_container(port)


### PR DESCRIPTION
# What

Fixes #439. The docker image could not be built due to incompatibility of `gevent==21.1.2` with the newer version of Cython installed as part of the alpine packages during the build. See related releases (21.8.0 and 21.12.0) at <https://www.gevent.org/changelog.html#id1>. 

## Original error

Example failing workflow ([here](https://github.com/pypiserver/pypiserver/runs/8200700190?check_suite_focus=true#step:6:268))
 
> ```plaintext
>   Error compiling Cython file:
>   ------------------------------------------------------------
>   ...
>   cdef load_traceback
>   cdef Waiter
>   cdef wait
>   cdef iwait
>   cdef reraise
>   cpdef GEVENT_CONFIG
>         ^
>   ------------------------------------------------------------
>   
>   src/gevent/_gevent_cgreenlet.pxd:182:6: Variables cannot be declared with 'cpdef'. Use 'cdef' instead.
> ```

## Related info

- See the issue discussed at `gevent`: https://github.com/gevent/gevent/issues/1801