### PR TITLE
fix: force setuptools update + no duplicate runs in GH Actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,13 +5,11 @@ name: CI
 on:
   # This will run when any branch or tag is pushed
   push:
-    # standalone is an old branch containing a fully functional pypiserver
-    # executable, from back in the day before docker & a better pip.
-    branches-ignore:
-      - standalone
+    branches:
+      - "master"
     tags:
       - "v**"
-  # Allowing to run on fork pull requests
+  # Allowing to run on fork and other pull requests
   pull_request:
 
 jobs:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,11 +27,9 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
       - name: Install dependencies
-        run: pip install tox==3.27.*
-      - name: Check version
-        run: python --version
-      - name: Check version 3
-        run: python3 --version
+        run: |
+          pip install --upgrade setuptools
+          pip install tox==3.27.*
       - name: Run tests
         run: tox -e py
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,6 +30,8 @@ jobs:
         run: pip install tox==3.27.*
       - name: Check version
         run: python --version
+      - name: Check version 3
+        run: python3 --version
       - name: Run tests
         run: tox -e py
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,7 +27,7 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
       - name: Install dependencies
-        run: pip install tox
+        run: pip install tox==3.27.*
       - name: Run tests
         run: tox -e py
 
@@ -104,7 +104,7 @@ jobs:
     steps:
       - uses: actions/checkout@master
       - name: Set up Python
-        uses: actions/setup-python@v3
+        uses: actions/setup-python@v4
         with:
           python-version: 3.x
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,6 +28,8 @@ jobs:
           python-version: ${{ matrix.python-version }}
       - name: Install dependencies
         run: pip install tox==3.27.*
+      - name: Check version
+        run: python --version
       - name: Run tests
         run: tox -e py
 


### PR DESCRIPTION
# What

This PR addresses 2 issues with current CI.

1. The failing tests on Python 3.6 due to `setuptools` being out of date (solution roughly based on https://github.com/docker-library/python/issues/170)
2. Currently, for the central repository PRs, GitHub Actions are running double: on `push` and `pull_request` triggers. 

## Changes

1. Forcing `setuptools` update before installing `tox`, seems to fix the problem with tests on Python 3.6.
2. Instead of duplicate runs, like #444, the actions are run only once (see this PR checks).
    - Before:  
      <img width="365" alt="image" src="https://user-images.githubusercontent.com/12134172/188691243-05db9ea1-0908-4a87-90f5-abea73814714.png">
    - Now:
      <img width="372" alt="image" src="https://user-images.githubusercontent.com/12134172/188691745-7eb28396-add9-4baa-b0e9-64af770f1a6d.png">
 
