### PR TITLE
fix: correct 1.5.1 tag date in CHANGES

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,7 +4,7 @@ Changelog
 2.0.0 (tbd)
 -----------
 
-1.5.1rc10-01-2022 (__rc__)
+1.5.1 (2022-10-18)
 --------------------------
 
 - 61e4487 ENH: add extremely basic /health endpoint (#396)


### PR DESCRIPTION
# What

I forgot to adjust the date for the latest [1.5.1 release](https://github.com/pypiserver/pypiserver/releases/tag/v1.5.1) in `CHANGES.rst`.   
This PR fixes the issue by adding the correct date retrospectively.