### PR TITLE
FEAT: Switch default hash-algo to sha256

### DIFF
--- a/pypiserver/config.py
+++ b/pypiserver/config.py
@@ -77,7 +77,7 @@ class DEFAULTS:
     AUTHENTICATE = ["update"]
     FALLBACK_URL = "https://pypi.org/simple/"
     HEALTH_ENDPOINT = "/health"
-    HASH_ALGO = "md5"
+    HASH_ALGO = "sha256"
     INTERFACE = "0.0.0.0"
     LOG_FRMT = "%(asctime)s|%(name)s|%(levelname)s|%(thread)d|%(message)s"
     LOG_ERR_FRMT = "%(body)s: %(exception)s \n%(traceback)s"

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -130,12 +130,12 @@ def test_fallback_url_default(main):
 
 def test_hash_algo_default(main):
     main([])
-    assert main.app._pypiserver_config.hash_algo == "md5"
+    assert main.app._pypiserver_config.hash_algo == "sha256"
 
 
 def test_hash_algo(main):
-    main(["--hash-algo=sha256"])
-    assert main.app._pypiserver_config.hash_algo == "sha256"
+    main(["--hash-algo=md5"])
+    assert main.app._pypiserver_config.hash_algo == "md5"
 
 
 def test_hash_algo_off(main):


### PR DESCRIPTION
I prepared a PR which switches default hash-algo to sha256 as discussed in #452. Created as draft PR as it probably should not be merged before major version bump to 2.0 is concrete.

Closes #452