### PR TITLE
chore: disable tests on Python3.6

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,8 +18,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version:
-          ["3.7", "3.8", "3.9", "3.10", "pypy3.9", "3.11", "3.12-dev"]
+        python-version: ["3.7", "3.8", "3.9", "3.10", "pypy3.9", "3.11"] # "3.12-dev"
 
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.7", "3.8", "3.9", "3.10", "pypy3.9"]  # "3.11-dev"
+        python-version:
+          ["3.7", "3.8", "3.9", "3.10", "pypy3.9", "3.11", "3.12-dev"]
 
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.6", "3.7", "3.8", "3.9", "3.10", "pypy3.9"]  # "3.11-dev"
+        python-version: ["3.7", "3.8", "3.9", "3.10", "pypy3.9"]  # "3.11-dev"
 
     steps:
       - uses: actions/checkout@v3

--- a/requirements/dev.pip
+++ b/requirements/dev.pip
@@ -6,6 +6,6 @@
 -r exe.pip
 -r test.pip
 
-black
+black==22.12.*
 docopt  # For `/bin/bumpver.py`.
 mypy; implementation_name == 'cpython'


### PR DESCRIPTION
# What

Since the update of `ubuntu-latest` image in [setup-python](https://github.com/actions/setup-python) GitHub Action to `Ubuntu 22.04`, Python 3.6 is no longer available by default. https://github.com/pypiserver/pypiserver/actions/runs/3861663821/jobs/6683883640#step:3:10. See related issue: https://github.com/actions/setup-python/issues/561.  

Since Python 3.6 is declared "end of life" and is planned to be deprecated for `pypiserver 2.0.0`, I believe it's worth disabling these tests. Related to https://github.com/pypiserver/pypiserver/issues/107 and the discussion with @cclauss in https://github.com/pypiserver/pypiserver/pull/447. 