### PR TITLE
fix: explicit optional types in `config.py`

### DIFF
--- a/pypiserver/config.py
+++ b/pypiserver/config.py
@@ -828,7 +828,7 @@ class Config:
         return default_config.with_updates(**overrides)
 
     @classmethod
-    def from_args(cls, args: t.Sequence[str] = None) -> Configuration:
+    def from_args(cls, args: t.Optional[t.Sequence[str]] = None) -> Configuration:
         """Construct a Config from the passed args or sys.argv."""
         # If pulling args from sys.argv (commandline arguments), argv[0] will
         # be the program name, (i.e. pypi-server), so we don't need to

--- a/pypiserver/config.py
+++ b/pypiserver/config.py
@@ -689,7 +689,7 @@ class RunConfig(_ConfigCommon):
         log_req_frmt: str,
         log_res_frmt: str,
         log_err_frmt: str,
-        auther: t.Callable[[str, str], bool] = None,
+        auther: t.Optional[t.Callable[[str, str], bool]] = None,
         **kwargs: t.Any,
     ) -> None:
         """Construct a RuntimeConfig."""

--- a/pypiserver/config.py
+++ b/pypiserver/config.py
@@ -828,7 +828,9 @@ class Config:
         return default_config.with_updates(**overrides)
 
     @classmethod
-    def from_args(cls, args: t.Optional[t.Sequence[str]] = None) -> Configuration:
+    def from_args(
+        cls, args: t.Optional[t.Sequence[str]] = None
+    ) -> Configuration:
         """Construct a Config from the passed args or sys.argv."""
         # If pulling args from sys.argv (commandline arguments), argv[0] will
         # be the program name, (i.e. pypi-server), so we don't need to


### PR DESCRIPTION
# What

This solves [a small typing issue](https://github.com/pypiserver/pypiserver/actions/runs/4048433497/jobs/6963668078#step:5:1) in `config.py`:

```bash
...
Run mypy docker/test_docker.py pypiserver/config.py  tests/test_init.py
pypiserver/config.py:692:48: error: Incompatible default for argument "auther" (default has type "None", argument has type "Callable[[str, str], bool]")  [assignment]
...
pypiserver/config.py:831:48: error: Incompatible default for argument "args" (default has type "None", argument has type "Sequence[str]")  [assignment]
...
```

Solved by explicitly declaring it as `t.Optional`.
