### PR TITLE
Upgrade to psf/black stable style 2023

### DIFF
--- a/pypiserver/cache.py
+++ b/pypiserver/cache.py
@@ -14,7 +14,6 @@ try:
     ENABLE_CACHING = True
 
 except ImportError:
-
     Observer = None
 
     ENABLE_CACHING = False

--- a/pypiserver/config.py
+++ b/pypiserver/config.py
@@ -621,7 +621,6 @@ class _ConfigCommon:
         return levels.get(self.verbosity, logging.NOTSET)
 
     def get_backend(self, arg: str) -> IBackend:
-
         available_backends: t.Dict[str, BackendFactory] = {
             "auto": get_file_backend,
             "simple-dir": SimpleFileBackend,

--- a/requirements/dev.pip
+++ b/requirements/dev.pip
@@ -6,6 +6,6 @@
 -r exe.pip
 -r test.pip
 
-black==22.12.*
+black
 docopt  # For `/bin/bumpver.py`.
 mypy; implementation_name == 'cpython'

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -39,7 +39,6 @@ class main_wrapper:
 
 @pytest.fixture()
 def main(monkeypatch):
-
     main = main_wrapper()
 
     def run(**kwargs):


### PR DESCRIPTION
@dee-me-tree-or-love Your review, please.

Updating https://github.com/psf/black -> 23.1.0.
* https://github.com/psf/black/blob/main/CHANGES.md#2310

> This is the first [psf/black] release of 2023, and following our [stability policy](https://black.readthedocs.io/en/stable/the_black_code_style/index.html#stability-policy), it comes with a number of improvements to our stable style…