### PR TITLE
Extend auther function to also take action as an argument

### DIFF
--- a/pypiserver/_app.py
+++ b/pypiserver/_app.py
@@ -42,7 +42,8 @@ class auth:
                     raise HTTPError(
                         401, headers={"WWW-Authenticate": 'Basic realm="pypi"'}
                     )
-                if not config.auther(*request.auth):
+
+                if not config.auther(request.auth[0], request.auth[1], self.action):
                     raise HTTPError(403)
             return method(*args, **kwargs)
 

--- a/pypiserver/config.py
+++ b/pypiserver/config.py
@@ -689,7 +689,7 @@ class RunConfig(_ConfigCommon):
         log_req_frmt: str,
         log_res_frmt: str,
         log_err_frmt: str,
-        auther: t.Optional[t.Callable[[str, str], bool]] = None,
+        auther: t.Callable[[str, str, str], bool] = None,
         **kwargs: t.Any,
     ) -> None:
         """Construct a RuntimeConfig."""
@@ -736,7 +736,7 @@ class RunConfig(_ConfigCommon):
         }
 
     def get_auther(
-        self, passed_auther: t.Optional[t.Callable[[str, str], bool]]
+        self, passed_auther: t.Optional[t.Callable[[str, str, str], bool]]
     ) -> t.Callable[[str, str], bool]:
         """Create or retrieve an authentication function."""
         # The auther may be specified directly as a kwarg in the API interface
@@ -752,11 +752,11 @@ class RunConfig(_ConfigCommon):
                     f" (-P={self.password_file!r}) must also be empty ('.')!"
                 )
             # Return an auther that always returns true.
-            return lambda _uname, _pw: True
+            return lambda _uname, _pw, _action: True
         # Now, if there was no password file specified, we can return an auther
         # that always returns False, since there is no way to authenticate.
         if self.password_file is None:
-            return lambda _uname, _pw: False
+            return lambda _uname, _pw, _action: False
         # Finally, if a password file was specified, we'll load it up with
         # Htpasswd and return a callable that checks it.
         if HtpasswdFile is None:
@@ -771,7 +771,7 @@ class RunConfig(_ConfigCommon):
 
         # Construct a local closure over the loaded PW file and return as our
         # authentication function.
-        def auther(uname: str, pw: str) -> bool:
+        def auther(uname: str, pw: str, action: str) -> bool:
             loaded_pw_file.load_if_changed()
             return loaded_pw_file.check_password(uname, pw)
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -289,7 +289,9 @@ _CONFIG_TEST_PARAMS: t.Tuple[ConfigTestCase, ...] = (
         exp_config_type=RunConfig,
         exp_config_values={
             "authenticate": [],
-            "_test": lambda conf: bool(conf.auther("foo", "bar")) is True,
+            "_test": lambda conf: (
+                bool(conf.auther("foo", "bar", "download")) is True
+            ),
         },
     ),
     # passwords
@@ -308,8 +310,8 @@ _CONFIG_TEST_PARAMS: t.Tuple[ConfigTestCase, ...] = (
         exp_config_values={
             "password_file": HTPASS_TEST_FILE,
             "_test": lambda conf: (
-                bool(conf.auther("foo", "bar")) is False
-                and bool(conf.auther("a", "a")) is True
+                bool(conf.auther("foo", "bar", "download")) is False
+                and bool(conf.auther("a", "a", "download")) is True
             ),
         },
     ),
@@ -322,8 +324,8 @@ _CONFIG_TEST_PARAMS: t.Tuple[ConfigTestCase, ...] = (
             "password_file": HTPASS_TEST_FILE,
             "_test": (
                 lambda conf: (
-                    bool(conf.auther("foo", "bar")) is False
-                    and conf.auther("a", "a") is True
+                    bool(conf.auther("foo", "bar", "download")) is False
+                    and conf.auther("a", "a", "download") is True
                 )
             ),
         },
@@ -336,7 +338,9 @@ _CONFIG_TEST_PARAMS: t.Tuple[ConfigTestCase, ...] = (
         exp_config_type=RunConfig,
         exp_config_values={
             "password_file": ".",
-            "_test": lambda conf: bool(conf.auther("foo", "bar")) is True,
+            "_test": lambda conf: (
+                bool(conf.auther("foo", "bar", "download")) is True
+            ),
         },
     ),
     # disable-fallback


### PR DESCRIPTION
I also [opened this PR](https://github.com/pypiserver/pypiserver/pull/480), but this solution was simpler for my local use, so I figured I might as well propose this change.