### PR TITLE
DRAFT: Support Pluggable Storage Backends

### DIFF
--- a/pypiserver/__main__.py
+++ b/pypiserver/__main__.py
@@ -10,7 +10,7 @@ from pathlib import Path
 from wsgiref.simple_server import WSGIRequestHandler
 
 import functools as ft
-from pypiserver.config import Config, UpdateConfig
+from pypiserver.config import BackendConfig, Config, UpdateConfig
 
 log = logging.getLogger("pypiserver.main")
 
@@ -149,6 +149,14 @@ def main(argv: t.Sequence[str] = None) -> None:
             stable_only=config.allow_unstable,
             ignorelist=config.ignorelist,
         )
+        return
+
+    if isinstance(config, BackendConfig):
+        from pypiserver.backend import get_all_backends
+
+        backends = get_all_backends()
+        for b in backends:
+            print(b)
         return
 
     # Fixes #49:

--- a/setup.py
+++ b/setup.py
@@ -81,6 +81,11 @@ setup(
     entry_points={
         "paste.app_factory": ["main=pypiserver:paste_app_factory"],
         "console_scripts": ["pypi-server=pypiserver.__main__:main"],
+        "pypiserver_backends": [
+            "simple-dir=pypiserver.backend:SimpleFileBackend",
+            "cached-dir=pypiserver.backend:CachingFileBackend",
+            "auto=pypiserver.backend:get_file_backend",
+        ],
     },
     options={"bdist_wheel": {"universal": True}},
     platforms=["any"],


### PR DESCRIPTION
Feel free to close if this is something there isn't any upstream appetite for. There seems to be more than just me that wants `pypiserver` to work transparently on object storage like S3.

* [`pipy-cloud`](https://github.com/stevearc/pypicloud) -- which is [maintenance](https://github.com/stevearc/pypicloud/issues/325) mode.
* https://github.com/burnsred/pypiserver-to-s3
* https://mek97.github.io/pensieve/pypiserver-s3

This PR (is the start of) making the pypiserver able to support custom storage backends.

Here's a PoC backend for S3 https://github.com/estheruary/pypiserver-backend-s3 that can live standalone and be installed separately from `pypiserver` itself so this repo doesn't have to have the maintenance burden (and dependencies ) of every backend anyone could possibly want.

Still a lot to do obviously, like adding some args on `pypi-server` to pass config options to the backend so you don't have to use env vars, tests, documentation.

I think the flow is really nice.

```bash
$ pip install pypiserver pypiserver-backend-s3
$ pypi-server backends
auto
cached-dir
simple-dir
s3

$ pypi-server run --backend=s3 [other args]
```