### PR TITLE
chore: add GitHub container registry for stable images

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -135,13 +135,20 @@ jobs:
           password: ${{ secrets.PYPI_API_TOKEN }}
           print-hash: true
 
-  ## DOCKER
+  ## DOCKER (DOCKER HUB & CONTAINER REGISTRY)
 
   # figure out which docker tags we need to push
   docker-determine-tags:
     runs-on: "ubuntu-latest"
     needs:
       - "tests"
+    env:
+      STABLE_IMAGES: '["pypiserver/pypiserver", "ghcr.io/pypiserver/pypiserver"]'
+      FLEXIBLE_IMAGES: '["pypiserver/pypiserver"]'
+    outputs:
+      tags: "${{ steps.tags.outputs.tags }}"
+      has_tags: "${{ steps.has_tags.outputs.has_tags }}"
+      images: ${{ contains(steps.tags.outputs.tags, 'unstable') && env.FLEXIBLE_IMAGES || env.STABLE_IMAGES }}
     steps:
       - uses: "actions/checkout@v3"
 
@@ -166,10 +173,6 @@ jobs:
         run: >-
           echo "::set-output name=has_tags::$(bin/ci_helper.py ${{ github.ref }} has_tags)"
 
-    outputs:
-      tags: "${{ steps.tags.outputs.tags }}"
-      has_tags: "${{ steps.has_tags.outputs.has_tags }}"
-
   # Deploy any needed docker tags
   deploy-docker:
     runs-on: "ubuntu-latest"
@@ -179,6 +182,7 @@ jobs:
     strategy:
       matrix:
         tag: "${{ fromJson(needs.docker-determine-tags.outputs.tags) }}"
+        image: "${{ fromJson(needs.docker-determine-tags.outputs.images) }}"
     steps:
       - uses: "actions/checkout@v3"
 
@@ -196,6 +200,13 @@ jobs:
           username: "${{ secrets.DOCKER_HUB_USER }}"
           password: "${{ secrets.DOCKER_HUB_TOKEN }}"
 
+      - name: "Login to GitHub Container Registry"
+        uses: "docker/login-action@v2"
+        with:
+          registry: "ghcr.io"
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
       - name: "Set up Docker Buildx"
         id: "buildx"
         uses: "docker/setup-buildx-action@v1"
@@ -208,7 +219,7 @@ jobs:
           file: "./Dockerfile"
           builder: "${{ steps.buildx.outputs.name }}"
           push: true
-          tags: "pypiserver/pypiserver:${{ matrix.tag }}"
+          tags: "${{ matrix.image }}:${{ matrix.tag }}"
           cache-from: "type=local,src=/tmp/.buildx-cache"
           cache-to: "type=local,dest=/tmp/.buildx-cache"
 

--- a/docs/contents/repo-maintenance/release-work.md
+++ b/docs/contents/repo-maintenance/release-work.md
@@ -14,6 +14,7 @@ flowchart LR
     pk["build-and-pack 📦"]
     py["pypi-index 🗃️"]
     do["docker-hub 🐳"]
+    gh["gh-container-registry 🚀"]
     gr["github-release 📣"]
 
     subgraph "Preparation 🌱"
@@ -23,7 +24,7 @@ flowchart LR
     rm-->ci-->pk
     end
     subgraph "Deploy 🌳"
-    pk--> py & do & gr
+    pk--> py & do & gh & gr
     end
 ```
 
@@ -100,6 +101,15 @@ the wheels to the [`pypiserver` PyPi project](https://pypi.org/project/pypiserve
 If all is successful so far, [`ci.yml`](../../../.github/workflows/ci.yml) tags
 the built docker images and pushes them to the
 [`pypiserver` Docker Hub repository](https://hub.docker.com/r/pypiserver/pypiserver).
+
+#### Publish to GitHub Container Registry 🚀
+
+> 🏷️ Docker image *tags* are determined on the fly.
+
+For all `stable` (i.e. `latest`, tag, release ...) tags derived by
+[`ci.yml`](../../../.github/workflows/ci.yml) tags,
+the built docker images are *also* pushed to
+[`pypiserver` GitHub Container Registry](https://github.com/orgs/pypiserver/packages?repo_name=pypiserver).
 
 #### Publish a GitHub Release draft 📣
 


### PR DESCRIPTION
# What

Closes https://github.com/pypiserver/pypiserver/issues/482

This PR adds basic support for GHCR as a backup docker container registry.

## Changes

- Images tagged with stable labels (`latest`, release, version tags) are also pushed to GHCR.