### PR TITLE
fix: specify long_description as MD type

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -41,7 +41,7 @@ setup(
     name="pypiserver",
     description="A minimal PyPI server for use with pip/easy_install.",
     long_description=read_file("README.md"),
-    long_description_content_type='text/markdown',
+    long_description_content_type="text/markdown",
     version=get_version(),
     packages=["pypiserver"],
     package_data={"pypiserver": ["welcome.html"]},

--- a/setup.py
+++ b/setup.py
@@ -41,6 +41,7 @@ setup(
     name="pypiserver",
     description="A minimal PyPI server for use with pip/easy_install.",
     long_description=read_file("README.md"),
+    long_description_content_type='text/markdown',
     version=get_version(),
     packages=["pypiserver"],
     package_data={"pypiserver": ["welcome.html"]},


### PR DESCRIPTION
# What

[Release of `2.0.0`](https://github.com/pypiserver/pypiserver/releases/tag/v2.0.0) didn't make it to the `PyPi` index [with an error on `long_description`](https://github.com/pypiserver/pypiserver/actions/runs/6370534716/job/17291871269#step:6:26) since it became MD. 

This PR fixes the issue. 