### PR TITLE
Fix: dockerhub description readme

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -226,6 +226,13 @@ jobs:
       - name: "Image digest"
         run: "echo ${{ steps.docker_build.outputs.digest }}"
 
+      - name: "Docker Hub Description"
+        uses: peter-evans/dockerhub-description@v3
+        with:
+          username: ${{ secrets.DOCKER_HUB_USER }}
+          password: ${{ secrets.DOCKER_HUB_TOKEN }}
+          repository: pypiserver/pypiserver
+
   ## GITHUB RELEASE DRAFT
 
   create_release:

--- a/setup.py
+++ b/setup.py
@@ -41,7 +41,7 @@ setup(
     name="pypiserver",
     description="A minimal PyPI server for use with pip/easy_install.",
     long_description=read_file("README.md"),
-    long_description_content_type='text/markdown',
+    long_description_content_type="text/markdown",
     version=get_version(),
     packages=["pypiserver"],
     package_data={"pypiserver": ["welcome.html"]},

--- a/setup.py
+++ b/setup.py
@@ -41,6 +41,7 @@ setup(
     name="pypiserver",
     description="A minimal PyPI server for use with pip/easy_install.",
     long_description=read_file("README.md"),
+    long_description_content_type='text/markdown',
     version=get_version(),
     packages=["pypiserver"],
     package_data={"pypiserver": ["welcome.html"]},


### PR DESCRIPTION
# What

Fixing the stale Docker Hub description for `pypiserver/pypiserver`.
It is a known issue and there are a few workarounds suggested here: https://github.com/docker/build-push-action/issues/21

