### PR TITLE
chore: make the last supported python version explicit in `ci.yaml`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,6 +12,9 @@ on:
   # Allowing to run on fork and other pull requests
   pull_request:
 
+env:
+  LAST_SUPPORTED_PYTHON: "3.11"
+
 jobs:
   test-python:
     runs-on: ubuntu-latest
@@ -43,7 +46,7 @@ jobs:
         uses: actions/setup-python@v4
         with:
           # Use the current version of Python
-          python-version: "3.x"
+          python-version: ${{ env.LAST_SUPPORTED_PYTHON }}
       - name: Install dependencies
         run: |
           pip install -r "requirements/dev.pip"
@@ -90,7 +93,7 @@ jobs:
         uses: actions/setup-python@v4
         with:
           # Use the current version of Python
-          python-version: "3.x"
+          python-version: ${{ env.LAST_SUPPORTED_PYTHON }}
       - name: Install test dependencies
         run: pip install -r "requirements/test.pip"
       - name: Install package
@@ -123,7 +126,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v4
         with:
-          python-version: 3.x
+          python-version: ${{ env.LAST_SUPPORTED_PYTHON }}
 
       - name: Build distribution _wheel_.
         run: |
@@ -154,7 +157,7 @@ jobs:
 
       - uses: "actions/setup-python@v4"
         with:
-          python-version: "3.x"
+          python-version: ${{ env.LAST_SUPPORTED_PYTHON }}
 
         # This script prints a JSON array of needed docker tags, depending on the
         # ref. That array is then used to construct the matrix of the

--- a/pypiserver/plugin.py
+++ b/pypiserver/plugin.py
@@ -18,6 +18,7 @@ with the following keyword arguments
 In the future, the plugin callable may be called with additional keyword
 arguments, so a plugin should accept a **kwargs variadic keyword argument.
 """
+
 from pypiserver.backend import SimpleFileBackend, CachingFileBackend
 from pypiserver import get_file_backend
 

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -1,6 +1,7 @@
 """
 Test module for app initialization
 """
+
 # Standard library imports
 import logging
 import pathlib


### PR DESCRIPTION
# What

The GH Actions are failing some checks that run on Python `3.x (== 3.12 at the time of writing)`. 

This PR ensures that the last _supported_ Python (in contrast to last _stable_) version is used in the CI/CD. 

## Related

- 🏗️ #539 coming up