### PR TITLE
fix: deprecated `setuptools.py` when building in `package.sh`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -129,8 +129,6 @@ jobs:
     runs-on: ubuntu-latest
     needs:
       - "tests"
-    # only if a tag is pushed
-    if: startsWith(github.event.ref, 'refs/tags/v')
     steps:
       - uses: actions/checkout@master
       - name: Set up Python
@@ -144,6 +142,8 @@ jobs:
 
       - name: Publish distribution 📦 to PyPI.
         uses: pypa/gh-action-pypi-publish@release/v1
+        # Push to PyPi only if a tag is pushed
+        if: startsWith(github.event.ref, 'refs/tags/v')
         with:
           password: ${{ secrets.PYPI_API_TOKEN }}
           print-hash: true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -136,6 +136,9 @@ jobs:
         with:
           python-version: ${{ env.LAST_SUPPORTED_PYTHON }}
 
+      - name: Install dev dependencies
+        run: pip install -r "requirements/dev.pip"
+
       - name: Build distribution _wheel_.
         run: |
           ./bin/package.sh

--- a/bin/package.sh
+++ b/bin/package.sh
@@ -6,4 +6,4 @@ my_dir=`dirname "$0"`
 cd $my_dir/..
 
 rm -r build/* dist/* || echo "no build/* or dist/* folder is found"
-python3 setup.py bdist_wheel sdist
+python3 -m build


### PR DESCRIPTION
# What

Since #539, we use Python 3.12 (`env.LAST_SUPPORTED_PYTHON`) to build distribution archives, but `package.sh` was not updated [overcome the deprecated use of `setup.py` as command line](https://packaging.python.org/en/latest/discussions/setup-py-deprecated/).

This PR offers a fix.

## Changes

- `package.sh` uses `python -m build` 
- `CI` builds the wheels in any case, but pushes to PyPi only on tags