### PR TITLE
test: Fix running `build` in offline test environment

### DIFF
--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -148,7 +148,10 @@ def wheel_file(project, tmp_path_factory):
     if re.match("^3\.7", sys.version):
         assert run_setup_py(project, f"bdist_wheel -d {distdir}") == 0
     else:
-        assert run_py_build(project, f"--wheel --outdir {distdir}") == 0
+        assert (
+            run_py_build(project, f"--wheel --no-isolation --outdir {distdir}")
+            == 0
+        )
     wheels = list(distdir.glob("centodeps*.whl"))
     assert len(wheels) > 0
     return wheels[0]


### PR DESCRIPTION
Fix the `build` calls to use `--no-isolation`, in order to fix regression in running tests in an offline environment.

Unlike the previous `setup.py` calls, `build` defaults to creating a new virtual environment to perform the build.  This, in turn, requires fetching the build dependencies from the Internet, effectively making the tests error out in an offline environment.  Passing `--no-isolation` makes `build` use the already-installed host dependencies instead.