### PR TITLE
Update Deprecated Compose Commands for Pypiserver Services

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -48,7 +48,7 @@ services:
             - type: bind
               source: ./auth
               target: /data/auth
-        command: -P /data/auth/.htpasswd -a update,download,list /data/packages
+        command: run -P /data/auth/.htpasswd -a update,download,list /data/packages
         ports:
             - "8081:8080"
 
@@ -96,7 +96,7 @@ services:
             - type: bind
               source: ./packages
               target: /data/packages
-        command: -P /data/auth/.htpasswd -a update,download,list /data/packages
+        command: run -P /data/auth/.htpasswd -a update,download,list /data/packages
         labels:
             # Expose container to Traefik
             - "traefik.enable=true"


### PR DESCRIPTION
pypiserver compose services were using the deprecated `pypiserver` command instead of `pypiserver run` command.