### PR TITLE
chore: deprecated `types-pkg_resources`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,7 +60,6 @@ jobs:
       - name: Install dependencies
         run: |
           pip install -r "requirements/dev.pip"
-          pip install types-pkg_resources # one of mypy required stubs
       - name: Check types
         # individual mypy files for now, until we get the rest
         # of the project typechecking

--- a/requirements/dev.pip
+++ b/requirements/dev.pip
@@ -8,4 +8,5 @@
 
 black
 docopt  # For `/bin/bumpver.py`.
+types-setuptools # For mypy stubs
 mypy; implementation_name == 'cpython'


### PR DESCRIPTION
# What

This PR removes the deprecated `types-pkg_resources` type checking stub.

> [!NOTE]
> <img width="1050" alt="image" src="https://github.com/user-attachments/assets/ed47adf1-64c5-43a2-9ea9-ae8f8b09bc70">
