### PR TITLE
Update alpine image to 3.20 and python version to 3.10

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.8-alpine3.12 as base
+FROM python:3.10-alpine3.20 as base
 
 # Copy the requirements & code and install them
 # Do this in a separate image in a separate directory


### PR DESCRIPTION
Move to latest alpine image, and later version of python.

This upgrades many packages within the container and fixes many security vulnerabilities.

Python 3.11 fails to build so settled on python 3.10 for now.