### PR TITLE
chore: finish move to `main`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,7 +6,6 @@ on:
   # This will run when any branch or tag is pushed
   push:
     branches:
-      - "master" # TODO(tech-debt): remove after switching the default branch
       - "main"
     tags:
       - "v**"

--- a/.github/workflows/rt.yml
+++ b/.github/workflows/rt.yml
@@ -20,7 +20,7 @@ on:
 jobs:
   new-tag:
     # TODO(tech-debt): cleanup after switching the default branch
-    if: ${{ github.ref_name == 'master' || github.ref_name == 'main' }}
+    if: ${{ github.ref_name == 'main' }}
     runs-on: ubuntu-latest
     env:
       CHANGE_FILE: CHANGES.rst


### PR DESCRIPTION
# What

> [!TIP]
> Closes #420 

With the rename to `main` complete, this PR removes the no longer needed references to `master` branch. 
