### PR TITLE
Pull through - allow automatic downloads of packages from pypi.org

### DIFF
--- a/pypiserver/_app.py
+++ b/pypiserver/_app.py
@@ -294,6 +294,20 @@ def simple(project):
     if project != normalized:
         return redirect(f"/simple/{normalized}/", 301)
 
+    # pip install always uses 2 requests, first to get the list of versions
+    # and then to download the package.
+    # If we only search for the package on the local filesystem, we will
+    # might not be able to return the list containing the version.
+    # Hence, if pull_through is enabled, we will fetch the version list
+    # from pypi.org and then return the list of versions.
+
+    # If the packages version is not found, in pypi.org, we will return a 404
+
+    # Serving the actual package is handled by the /packages/ route
+    # And in this route, we will first attempt to fetch the package from the
+    # local filesystem, if not found, we will fetch it from pypi.org and save
+    # it to the local filesystem and then serve it.
+
     packages = sorted(
         config.backend.find_project_packages(project),
         key=lambda x: (x.parsed_version, x.relfn),

--- a/pypiserver/_app.py
+++ b/pypiserver/_app.py
@@ -26,6 +26,10 @@ from .bottle import (
 from .pkg_helpers import guess_pkgname_and_version, normalize_pkgname_for_url
 
 log = logging.getLogger(__name__)
+# your editor may complain about `config` being undefined.
+# To understand why this code work, see how pypiserver/__init__.py
+# imports the _app module and sets the `config` variable in _app.py
+# insidet the function app_from_config.
 config: RunConfig
 app = Bottle()
 

--- a/pypiserver/_app.py
+++ b/pypiserver/_app.py
@@ -313,21 +313,25 @@ def simple(project):
     # it to the local filesystem and then serve it.
     if config.pull_through:
         # Getting a list of packages and hashes
-        rgx = re.compile(r'href=\"(?P<url>.*)#sha256=(?P<meta>.*\") ?>(?P<pkgversion>.*)</a><br />')
-        res = urllib.request.urlopen(f"{config.fallback_url.rstrip('/')}/{project}/")
-        content = res.read().decode('utf-8').split('\n')
+        rgx = re.compile(
+            r"href=\"(?P<url>.*)#sha256=(?P<meta>.*\") ?>(?P<pkgversion>.*)</a><br />"
+        )
+        res = urllib.request.urlopen(
+            f"{config.fallback_url.rstrip('/')}/{project}/"
+        )
+        content = res.read().decode("utf-8").split("\n")
         new_content = []
         for line in content:
             m = rgx.search(line)
             if m:
                 gdict = m.groupdict()
-                vrsn = gdict['pkgversion']
-                meta = gdict['meta']
+                vrsn = gdict["pkgversion"]
+                meta = gdict["meta"]
                 val = f'<a href="http://{config.host}:{config.port}/packages/{vrsn}#{meta}>{vrsn}</a><br />'
             else:
                 val = line
             new_content.append(val)
-        body = '\n'.join(new_content)
+        body = "\n".join(new_content)
         response = HTTPResponse(body=body, status=200)
         return response
 
@@ -406,13 +410,17 @@ def list_packages():
 @auth("download")
 def serve_metadata(pkg_version):
     pkg, version, _ = pkg_version.split("-", 2)
-    urs = urlsplit(config.fallback_url.rstrip('/'))
+    urs = urlsplit(config.fallback_url.rstrip("/"))
     json_url = f"{urs.scheme}://{urs.hostname}/pypi/{pkg}/json"
     response = urllib.request.urlopen(json_url)
-    content = json.loads(response.read().decode('utf-8'))
-    metadata_url = [i['url'] for i in content['releases'][version] if i['packagetype'] == 'bdist_wheel'][0]
-    response = urllib.request.urlopen(metadata_url+".metadata")
-    content = response.read().decode('utf-8')
+    content = json.loads(response.read().decode("utf-8"))
+    metadata_url = [
+        i["url"]
+        for i in content["releases"][version]
+        if i["packagetype"] == "bdist_wheel"
+    ][0]
+    response = urllib.request.urlopen(metadata_url + ".metadata")
+    content = response.read().decode("utf-8")
     response = HTTPResponse(body=content, status=200)
     return response
 
@@ -437,9 +445,9 @@ def server_static(filename):
         log.debug(f"Package {filename} not found localy, pulling it")
         fetch_package(filename, str(config.roots[0]))
         response = static_file(
-             filename,
-             root=str(config.roots[0]),
-             mimetype=mimetypes.guess_type(filename)[0]
+            filename,
+            root=str(config.roots[0]),
+            mimetype=mimetypes.guess_type(filename)[0],
         )
 
     if config.cache_control:

--- a/pypiserver/config.py
+++ b/pypiserver/config.py
@@ -319,8 +319,8 @@ def add_common_args(parser: argparse.ArgumentParser) -> None:
         help=(
             "Enable pull-through caching. This will cache packages from "
             "pypi.org."
-            )
-        )
+        ),
+    )
 
     parser.add_argument(
         "--version",
@@ -354,7 +354,10 @@ def get_parser() -> argparse.ArgumentParser:
     run_parser = subparsers.add_parser(
         "run",
         formatter_class=PreserveWhitespaceRawTextHelpFormatter,
-        help="Run pypiserver, serving packages from PACKAGES_DIRECTORY",
+        help=(
+            "Run pypiserver, serving packages from one or more "
+            "package directories"
+        ),
     )
 
     add_common_args(run_parser)

--- a/pypiserver/config.py
+++ b/pypiserver/config.py
@@ -314,6 +314,15 @@ def add_common_args(parser: argparse.ArgumentParser) -> None:
     )
 
     parser.add_argument(
+        "--pull-through",
+        action="store_true",
+        help=(
+            "Enable pull-through caching. This will cache packages from "
+            "pypi.org."
+            )
+        )
+
+    parser.add_argument(
         "--version",
         action="version",
         version=__version__,
@@ -596,6 +605,7 @@ class _ConfigCommon:
         log_stream: t.Optional[t.IO],
         hash_algo: t.Optional[str],
         backend_arg: str,
+        pull_through: bool = False,
     ) -> None:
         """Construct a RuntimeConfig."""
         # Global arguments
@@ -607,6 +617,7 @@ class _ConfigCommon:
         self.roots = roots
         self.hash_algo = hash_algo
         self.backend_arg = backend_arg
+        self.pull_through = pull_through
 
         # Derived properties are directly based on other properties and are not
         # included in equality checks.
@@ -641,6 +652,7 @@ class _ConfigCommon:
             roots=namespace.package_directory,
             hash_algo=namespace.hash_algo,
             backend_arg=namespace.backend_arg,
+            pull_through=namespace.pull_through,
         )
 
     @property
@@ -724,6 +736,7 @@ class RunConfig(_ConfigCommon):
         log_res_frmt: str,
         log_err_frmt: str,
         auther: t.Optional[t.Callable[[str, str], bool]] = None,
+        pull_through: bool = False,
         **kwargs: t.Any,
     ) -> None:
         """Construct a RuntimeConfig."""
@@ -745,6 +758,7 @@ class RunConfig(_ConfigCommon):
         # Derived properties
         self._derived_properties = self._derived_properties + ("auther",)
         self.auther = self.get_auther(auther)
+        self.pull_through = pull_through
 
     @classmethod
     def kwargs_from_namespace(
@@ -767,6 +781,7 @@ class RunConfig(_ConfigCommon):
             "log_req_frmt": namespace.log_req_frmt,
             "log_res_frmt": namespace.log_res_frmt,
             "log_err_frmt": namespace.log_err_frmt,
+            "pull_through": namespace.pull_through,
         }
 
     def get_auther(

--- a/pypiserver/manage.py
+++ b/pypiserver/manage.py
@@ -140,7 +140,7 @@ class PipCmd:
         cmd_root,
         destdir,
         pkg_name,
-        pkg_version,
+        pkg_version=None,
         index="https://pypi.org/simple",
     ):
         """Yield an update command for pip."""
@@ -148,7 +148,26 @@ class PipCmd:
             yield part
         for part in ("--no-deps", "-i", index, "-d", destdir):
             yield part
-        yield "{}=={}".format(pkg_name, pkg_version)
+        if pkg_version:
+            yield "{}=={}".format(pkg_name, pkg_version)
+        yield "{}".format(pkg_name)
+
+
+def fetch_package(pkg: str, destdir: str):
+    """fetch a package."""
+    print(
+        f"# fetch {pkg} "
+    )
+
+    cmd = tuple(
+        PipCmd.update(
+            PipCmd.update_root(pip.__version__),
+            destdir or os.path.dirname(pkg.replaces.fn),
+            pkg,
+        )
+    )
+    print(" ".join(cmd), end="\n\n")
+    call(cmd)
 
 
 def update_package(pkg, destdir, dry_run=False):

--- a/pypiserver/manage.py
+++ b/pypiserver/manage.py
@@ -5,8 +5,8 @@ from __future__ import absolute_import, print_function, unicode_literals
 import itertools
 import json
 import os
+import re
 import sys
-from distutils.version import LooseVersion
 from pathlib import Path
 from subprocess import call
 from urllib.error import URLError
@@ -123,7 +123,7 @@ def find_updates(pkgset, stable_only=True):
 
 class PipCmd:
     """Methods for generating pip commands."""
-
+    
     @staticmethod
     def update_root(pip_version):
         """Yield an appropriate root command depending on pip version.
@@ -142,15 +142,25 @@ class PipCmd:
         pkg_name,
         pkg_version=None,
         index="https://pypi.org/simple",
+        deps=False,
+        wheel=True,
     ):
         """Yield an update command for pip."""
         for part in cmd_root:
             yield part
-        for part in ("--no-deps", "-i", index, "-d", destdir):
-            yield part
+        if deps:
+            for part in ("-i", index, "-d", destdir):
+                yield part
+        else:
+            for part in ("--no-deps", "-i", index, "-d", destdir):
+                yield part
+        if not wheel:
+            for part in ("--no-binary", ":all:", "--no-build-isolation"):
+                yield part
         if pkg_version:
             yield "{}=={}".format(pkg_name, pkg_version)
-        yield "{}".format(pkg_name)
+        else:
+            yield "{}".format(pkg_name)
 
 
 def fetch_package(pkg: str, destdir: str):
@@ -158,12 +168,23 @@ def fetch_package(pkg: str, destdir: str):
     print(
         f"# fetch {pkg} "
     )
-
+    # convert pkg-version to pkg==version
+    pkg, version, _, frmt = re.search(
+        r"(?P<project>.*)-(?P<version>.*)-(?P<constraints>.*-.*-.*)(?P<frmt>\.whl|\.zip|\.tar\.gz)$",
+        pkg).groups()
+    
+    if frmt.endswith(("tar.gz", "zip")):
+        wheel = False
+    else:
+        wheel = True
     cmd = tuple(
         PipCmd.update(
-            PipCmd.update_root(pip.__version__),
-            destdir or os.path.dirname(pkg.replaces.fn),
+            ("pip", "download"),
+            destdir,
             pkg,
+            version,
+            deps=True,
+            wheel=wheel
         )
     )
     print(" ".join(cmd), end="\n\n")
@@ -184,7 +205,7 @@ def update_package(pkg, destdir, dry_run=False):
             pkg.version,
         )
     )
-
+    print(cmd)
     print(" ".join(cmd), end="\n\n")
     if not dry_run:
         call(cmd)

--- a/pypiserver/manage.py
+++ b/pypiserver/manage.py
@@ -123,7 +123,7 @@ def find_updates(pkgset, stable_only=True):
 
 class PipCmd:
     """Methods for generating pip commands."""
-    
+
     @staticmethod
     def update_root(pip_version):
         """Yield an appropriate root command depending on pip version.
@@ -165,26 +165,20 @@ class PipCmd:
 
 def fetch_package(pkg: str, destdir: str):
     """fetch a package."""
-    print(
-        f"# fetch {pkg} "
-    )
+    print(f"# fetch {pkg} ")
     # convert pkg-version to pkg==version
     pkg, version, _, frmt = re.search(
         r"(?P<project>.*)-(?P<version>.*)-(?P<constraints>.*-.*-.*)(?P<frmt>\.whl|\.zip|\.tar\.gz)$",
-        pkg).groups()
-    
+        pkg,
+    ).groups()
+
     if frmt.endswith(("tar.gz", "zip")):
         wheel = False
     else:
         wheel = True
     cmd = tuple(
         PipCmd.update(
-            ("pip", "download"),
-            destdir,
-            pkg,
-            version,
-            deps=True,
-            wheel=wheel
+            ("pip", "download"), destdir, pkg, version, deps=True, wheel=wheel
         )
     )
     print(" ".join(cmd), end="\n\n")


### PR DESCRIPTION
This can have a nice impact for making docker builds locally much faster. Also, for organizations who want faster builds, this is nice.
I imagine that if this is popular enough, this can also have an effect on traffic to pypi.org.

In any case, this still needs to be implemented.  I documented my thougts, how I would do it.
The simple naive solution is implemented in the first commit.
The second commit, explains why the naive solution does not work well, and how I would like to fix it.

Would love to get some feedback here.