### PR TITLE
fix: use `importlib_resources` only when needed

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,7 @@ setup_requires = [
 install_requires = [
     "pip>=7",
     "packaging>=23.2",
-    "importlib_resources;python_version>'3.8'",
+    "importlib_resources;python_version>'3.8' and python_version<'3.12'",
 ]
 
 
@@ -77,6 +77,8 @@ setup(
         "Operating System :: POSIX",
         "Operating System :: OS Independent",
         "Programming Language :: Python :: 3",
+        "Programming Language :: Python :: 3.7",
+        "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",
         "Programming Language :: Python :: 3.11",

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py310, py311, py312, pypy3
+envlist = py37, py38, py39, py310, py311, py312, pypy3
 
 [testenv]
 deps=-r{toxinidir}/requirements/test.pip


### PR DESCRIPTION
# What

We removed the upper bound for `importlib_resources`.
However, this package is required for the temporary support in Python version 3.8-3.12 only (see #539 when it was originally introduced).

## Changes

- return `importlib_resources` upper bound in `setup.py`
- fix the `envlist` of `tox.ini` to be aligned with `ci.yaml`