### PR TITLE
chore: update Docker Hub description only on tags

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -221,6 +221,7 @@ jobs:
 
       - name: Docker Hub Description
         uses: peter-evans/dockerhub-description@v3
+        if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')
         with:
           username: ${{ secrets.DOCKER_HUB_USER }}
           password: ${{ secrets.DOCKER_HUB_TOKEN }}


### PR DESCRIPTION
# What

Skip the `Docker Hub Description` CI/CD step if not on tags. 

## Why

Let's keep the Docker Hub description up to date with the latest stable image on the Docker Hub.