### PR TITLE
Feat: integrating prefix server mounting option from #647

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,7 @@ Table of Contents
     - [Custom Health Check Endpoint](#custom-health-check-endpoint)
       - [Configure a custom health endpoint by CLI arguments](#configure-a-custom-health-endpoint-by-cli-arguments)
       - [Configure a custom health endpoint by script](#configure-a-custom-health-endpoint-by-script)
+    - [Exposing `pypi-server` on a URL with a custom prefix](#exposing-pypi-server-on-a-url-with-a-custom-prefix)
   - [Sources](#sources)
   - [Known Limitations](#known-limitations)
   - [Similar Projects](#similar-projects)
@@ -1150,9 +1151,9 @@ bottle.run(app=app, host="0.0.0.0", port=8080, server="auto")
 
 Try **curl <http://localhost:8080/action/health>**
 
-### Exposing `pypi-server` on a custom prefix URL
+### Exposing `pypi-server` on a URL with a custom prefix
 
-The `--server-base-url` config option enables hosting your `pypi-server` deployment behind a URL prefix.  
+The `--server-base-url` config option enables hosting your `pypi-server` deployment behind a URL prefix.
 
 It can come handy when you are exposing `pypi-server` through a proxy or ingress.
 
@@ -1164,7 +1165,7 @@ It can come handy when you are exposing `pypi-server` through a proxy or ingress
 
 1. And it is accessible at the following URL:
 
-  ```bash
+   ```bash
    $ curl http://localhost:8080/prefix/
    <html lang="en">
    <head>

--- a/README.md
+++ b/README.md
@@ -154,9 +154,9 @@ Table of Contents
 
    ```text
    usage: pypi-server [-h] [-v] [--log-file FILE] [--log-stream STREAM]
-                     [--log-frmt FORMAT] [--hash-algo HASH_ALGO]
-                     [--backend {auto,simple-dir,cached-dir}] [--version]
-                     {run,update} ...
+                      [--log-frmt FORMAT] [--hash-algo HASH_ALGO]
+                      [--backend {auto,simple-dir,cached-dir}] [--version]
+                      {run,update} ...
 
    start PyPI compatible package server serving packages from PACKAGES_DIRECTORY. If PACKAGES_DIRECTORY is not given on the command line, it uses the default ~/packages. pypiserver scans this directory recursively for packages. It skips packages and directories starting with a dot. Multiple package directories may be specified.
 
@@ -169,7 +169,7 @@ Table of Contents
                            printed to stdout for introspection or pipelining. See
                            the `-x` option for updating packages directly.
 
-   optional arguments:
+   options:
      -h, --help            show this help message and exit
      -v, --verbose         Enable verbose logging; repeat for more verbosity.
      --log-file FILE       Write logging info into this FILE, as well as to
@@ -208,12 +208,13 @@ usage: pypi-server run [-h] [-v] [--log-file FILE] [--log-stream STREAM]
                        [-o] [--welcome HTML_FILE] [--cache-control AGE]
                        [--log-req-frmt FORMAT] [--log-res-frmt FORMAT]
                        [--log-err-frmt FORMAT]
-                       [package_directory [package_directory ...]]
+                       [--server-base-url SERVER_BASE_URL]
+                       [package_directory ...]
 
 positional arguments:
   package_directory     The directory from which to serve packages.
 
-optional arguments:
+options:
   -h, --help            show this help message and exit
   -v, --verbose         Enable verbose logging; repeat for more verbosity.
   --log-file FILE       Write logging info into this FILE, as well as to
@@ -295,7 +296,9 @@ optional arguments:
   --log-err-frmt FORMAT
                         A format-string selecting Http-Error properties to
                         log; set to '%s' to see them all.
-
+  --server-base-url SERVER_BASE_URL
+                        Serve all routes under SERVER_BASE_URL prefix
+                        (default: {DEFAULTS.SERVER_BASE_URL})
 ```
 
 ### More details about pypi-server update
@@ -308,12 +311,12 @@ usage: pypi-server update [-h] [-v] [--log-file FILE] [--log-stream STREAM]
                           [--backend {auto,simple-dir,cached-dir}] [--version]
                           [-x] [-d DOWNLOAD_DIRECTORY] [-u]
                           [--blacklist-file IGNORELIST_FILE]
-                          [package_directory [package_directory ...]]
+                          [package_directory ...]
 
 positional arguments:
   package_directory     The directory from which to serve packages.
 
-optional arguments:
+options:
   -h, --help            show this help message and exit
   -v, --verbose         Enable verbose logging; repeat for more verbosity.
   --log-file FILE       Write logging info into this FILE, as well as to
@@ -1146,6 +1149,31 @@ bottle.run(app=app, host="0.0.0.0", port=8080, server="auto")
 ```
 
 Try **curl <http://localhost:8080/action/health>**
+
+### Exposing `pypi-server` on a custom prefix URL
+
+The `--server-base-url` config option enables hosting your `pypi-server` deployment behind a URL prefix.  
+
+It can come handy when you are exposing `pypi-server` through a proxy or ingress.
+
+1. Start the server with a custom URL prefix:
+
+   ```bash
+   pypi-server run --server-base-url /prefix/
+   ```
+
+1. And it is accessible at the following URL:
+
+  ```bash
+   $ curl http://localhost:8080/prefix/
+   <html lang="en">
+   <head>
+     <meta charset="utf-8">
+     <title>Welcome to pypiserver!</title>
+   </head>
+   <body>
+   # ...
+   ```
 
 ## Sources
 

--- a/docker/test_docker.py
+++ b/docker/test_docker.py
@@ -95,7 +95,9 @@ def wait_for_container(port: int, url_path: t.Optional[str] = None) -> None:
     """Wait for the container to be available."""
     for _ in range(60):
         try:
-            httpx.get(f"http://localhost:{port}" + url_path if url_path else "").raise_for_status()
+            httpx.get(
+                f"http://localhost:{port}" + url_path if url_path else ""
+            ).raise_for_status()
         except (httpx.RequestError, httpx.HTTPStatusError):
             time.sleep(1)
         else:

--- a/docker/test_docker.py
+++ b/docker/test_docker.py
@@ -742,7 +742,7 @@ class TestServerPrefix:
     @pytest.fixture(scope="class")
     def upload_mypkg(
         self,
-        container: ContainerInfo,  # pylint: disable=unused-argument
+        container: ContainerInfo,
         mypkg_paths: t.Dict[str, Path],
     ) -> None:
         """Upload mypkg to the container."""

--- a/docker/test_docker.py
+++ b/docker/test_docker.py
@@ -96,7 +96,7 @@ def wait_for_container(port: int, url_path: t.Optional[str] = None) -> None:
     for _ in range(60):
         try:
             httpx.get(
-                f"http://localhost:{port}" + url_path if url_path else ""
+                f"http://localhost:{port}" + (url_path if url_path else "")
             ).raise_for_status()
         except (httpx.RequestError, httpx.HTTPStatusError):
             time.sleep(1)

--- a/docker/test_docker.py
+++ b/docker/test_docker.py
@@ -91,7 +91,7 @@ def image() -> str:
     return tag
 
 
-def wait_for_container(port: int, url_path: str = None) -> None:
+def wait_for_container(port: int, url_path: t.Optional[str] = None) -> None:
     """Wait for the container to be available."""
     for _ in range(60):
         try:

--- a/docker/test_docker.py
+++ b/docker/test_docker.py
@@ -760,7 +760,7 @@ class TestServerPrefix:
             f"{mypkg_paths['dist_dir']}/*",
         )
 
-    @pytest.mark.usefixtures("upload_mypkg_heavy")
+    @pytest.mark.usefixtures("upload_mypkg")
     def test_download(self, container: ContainerInfo) -> None:
         """Download mypkg from the container."""
         with tempfile.TemporaryDirectory() as tmpdir:
@@ -773,9 +773,9 @@ class TestServerPrefix:
                 f"http://localhost:{container.port}{self.prefix_url}simple",
                 "--dest",
                 tmpdir,
-                "pypiserver_mypkg_heavy",
+                "pypiserver_mypkg",
             )
             assert any(
-                "pypiserver_mypkg_heavy" in path.name
+                "pypiserver_mypkg" in path.name
                 for path in Path(tmpdir).iterdir()
             )

--- a/pypiserver/__main__.py
+++ b/pypiserver/__main__.py
@@ -200,8 +200,8 @@ def main(argv: t.Sequence[str] = None) -> None:
             "Running bottle with selected server '%s'", config.server_method
         )
 
-    # We strip&check because bottle mount() will raise error if path has no segment. 
-    if config.server_base_url.strip('/'):
+    # We strip&check because bottle mount() will raise error if path has no segment.
+    if config.server_base_url.strip("/"):
         main_app = bottle.Bottle()
         main_app.mount(config.server_base_url, app)
     else:

--- a/pypiserver/config.py
+++ b/pypiserver/config.py
@@ -124,7 +124,9 @@ class DEFAULTS:
     PORT = 8080
     SERVER_METHOD = "auto"
     BACKEND = "auto"
-    SERVER_BASE_URL = "/"  # if server need to served under example.com/<SERVER_BASE_URL>
+    SERVER_BASE_URL = (
+        "/"  # if server need to served under example.com/<SERVER_BASE_URL>
+    )
 
 
 def auth_arg(arg: str) -> t.List[str]:

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -575,6 +575,21 @@ _CONFIG_TEST_PARAMS: t.Tuple[ConfigTestCase, ...] = (
             ),
         },
     ),
+    # server prefix
+    ConfigTestCase(
+        case="Run: default server base prefix is /",
+        args=["run"],
+        legacy_args=[],
+        exp_config_type=RunConfig,
+        exp_config_values={"server_base_url": "/"},
+    ),
+    ConfigTestCase(
+        case="Run: specified server base prefix is set",
+        args=["run", "--server-base-url", "/prefix"],
+        legacy_args=["--server-base-url", "/prefix"],
+        exp_config_type=RunConfig,
+        exp_config_values={"server_base_url": "/prefix"},
+    ),
     # ******************************************************************
     # Update subcommand args
     # ******************************************************************


### PR DESCRIPTION
# What

> [!TIP]
> For full description see #647.
>
> > Hi,
> > I have added an option to run bottle under a prefix.
> > 
> > All routes are served under // if specified with options --server-base-url PREFIX
>
> -- kudos @skapin : #647



A quick follow-up on the @skapin's nice feature from #647. 
Lint fixes, some testing, and docs.

## Needs

- [x] Formatting
- [x] Tests
- [x] Docs