### PR TITLE
feat: add upload-time metadata for uv exclude-newer

### DIFF
--- a/pypiserver/_app.py
+++ b/pypiserver/_app.py
@@ -88,7 +88,8 @@ def simple_project_versions(packages):
 
 
 class auth:
-    """decorator to apply authentication if specified for the decorated method & action"""
+    """decorator to apply authentication if specified for the decorated
+    method & action"""
 
     def __init__(self, action):
         self.action = action
@@ -97,7 +98,10 @@ class auth:
         def protector(*args, **kwargs):
             if self.action in config.authenticate:
                 if not request.auth or request.auth[1] is None:
-                    raise HTTPError(401, headers={"WWW-Authenticate": 'Basic realm="pypi"'})
+                    raise HTTPError(
+                        401,
+                        headers={"WWW-Authenticate": 'Basic realm="pypi"'},
+                    )
                 if not config.auther(*request.auth):
                     raise HTTPError(403)
             return method(*args, **kwargs)
@@ -439,7 +443,10 @@ def server_static(filename):
                 mimetype=mimetypes.guess_type(filename)[0],
             )
             if config.cache_control:
-                response.set_header("Cache-Control", f"public, max-age={config.cache_control}")
+                response.set_header(
+                    "Cache-Control",
+                    f"public, max-age={config.cache_control}",
+                )
             return response
 
     return HTTPError(404, f"Not Found ({filename} does not exist)\n\n")

--- a/pypiserver/_app.py
+++ b/pypiserver/_app.py
@@ -79,6 +79,7 @@ def simple_project_file_json(current_uri, package):
         "filename": os.path.basename(package.relfn),
         "url": simple_project_url(current_uri, package),
         "hashes": simple_project_hashes(package),
+        "size": os.path.getsize(package.fn),
         "upload-time": format_upload_time(package.upload_time),
     }
 

--- a/pypiserver/_app.py
+++ b/pypiserver/_app.py
@@ -26,10 +26,17 @@ from .bottle_wrapper import (
     template,
 )
 from .pkg_helpers import guess_pkgname_and_version, normalize_pkgname_for_url
+from .upload_time import format_upload_time
 
 log = logging.getLogger(__name__)
 config: RunConfig
 app = Bottle()
+
+PEP_691_JSON_CONTENT_TYPE = "application/vnd.pypi.simple.v1+json"
+PEP_691_JSON_ACCEPT_TYPES = (
+    PEP_691_JSON_CONTENT_TYPE,
+    "application/vnd.pypi.simple.latest+json",
+)
 
 
 def request_fullpath(request):
@@ -48,6 +55,38 @@ def get_bad_url_redirect_path(request, project):
     return uri
 
 
+def simple_project_url(current_uri, package):
+    return urljoin(current_uri, f"../../packages/{package.fname_and_hash}")
+
+
+def simple_project_hashes(package):
+    package.fname_and_hash
+    if not package.digest:
+        return {}
+
+    algo, sep, value = package.digest.partition("=")
+    if not sep or not value:
+        return {}
+    return {algo: value}
+
+
+def simple_project_file_json(current_uri, package):
+    assert package.fn is not None
+    assert package.relfn is not None
+    assert package.upload_time is not None
+
+    return {
+        "filename": os.path.basename(package.relfn),
+        "url": simple_project_url(current_uri, package),
+        "hashes": simple_project_hashes(package),
+        "upload-time": format_upload_time(package.upload_time),
+    }
+
+
+def simple_project_versions(packages):
+    return list(dict.fromkeys(package.version for package in packages))
+
+
 class auth:
     """decorator to apply authentication if specified for the decorated method & action"""
 
@@ -58,9 +97,7 @@ class auth:
         def protector(*args, **kwargs):
             if self.action in config.authenticate:
                 if not request.auth or request.auth[1] is None:
-                    raise HTTPError(
-                        401, headers={"WWW-Authenticate": 'Basic realm="pypi"'}
-                    )
+                    raise HTTPError(401, headers={"WWW-Authenticate": 'Basic realm="pypi"'})
                 if not config.auther(*request.auth):
                     raise HTTPError(403)
             return method(*args, **kwargs)
@@ -153,15 +190,14 @@ Upload = namedtuple("Upload", "pkg sig")
 
 
 def file_upload():
-    ufiles = Upload._make(
-        request.files.get(f, None) for f in ("content", "gpg_signature")
-    )
+    files_get = getattr(request.files, "get")
+    package_file = files_get("content", None)
+    signature_file = files_get("gpg_signature", None)
+    ufiles = Upload(package_file, signature_file)
     if not ufiles.pkg:
         raise HTTPError(400, "Missing 'content' file-field!")
-    if (
-        ufiles.sig
-        and f"{ufiles.pkg.raw_filename}.asc" != ufiles.sig.raw_filename
-    ):
+    signature_name = f"{ufiles.pkg.raw_filename}.asc"
+    if ufiles.sig and signature_name != ufiles.sig.raw_filename:
         raise HTTPError(
             400,
             f"Unrelated signature {ufiles.sig!r} for package {ufiles.pkg!r}!",
@@ -170,10 +206,9 @@ def file_upload():
     for uf in ufiles:
         if not uf:
             continue
-        if (
-            not is_valid_pkg_filename(uf.raw_filename)
-            or guess_pkgname_and_version(uf.raw_filename) is None
-        ):
+        invalid_name = not is_valid_pkg_filename(uf.raw_filename)
+        unknown_package = guess_pkgname_and_version(uf.raw_filename) is None
+        if invalid_name or unknown_package:
             raise HTTPError(400, f"Bad filename: {uf.raw_filename}")
 
         if not config.overwrite and config.backend.exists(uf.raw_filename):
@@ -183,15 +218,17 @@ def file_upload():
             )
 
             http_code = 409
-            # twine 1.7.0+ expects status 400 to match compatibility with pypi.org
+            # twine 1.7.0+ expects status 400 to match compatibility
+            # with pypi.org
             # see: https://github.com/pypa/twine/issues/1265
             if "twine" in request.headers.get("User-Agent", ""):
                 http_code = 400
 
+            overwrite_msg = f"Package {uf.raw_filename!r} already exists!\n"
+            overwrite_msg += "  You may start server with `--overwrite` option."
             raise HTTPError(
                 http_code,
-                f"Package {uf.raw_filename!r} already exists!\n"
-                "  You may start server with `--overwrite` option.",
+                overwrite_msg,
             )
 
         config.backend.add_package(uf.raw_filename, uf.file)
@@ -247,11 +284,8 @@ def handle_rpc():
     )
     log.debug(f"Processing RPC2 request for '{methodname}'")
     if methodname == "search":
-        value = (
-            parser.getElementsByTagName("string")[0]
-            .childNodes[0]
-            .wholeText.strip()
-        )
+        string_node = parser.getElementsByTagName("string")[0]
+        value = string_node.childNodes[0].wholeText.strip()
         response = []
         ordering = 0
         for p in config.backend.get_all_packages():
@@ -267,7 +301,9 @@ def handle_rpc():
                 response.append(d)
             ordering += 1
         call_string = xmlrpclib.dumps(
-            (response,), "search", methodresponse=True
+            (response,),
+            "search",
+            methodresponse=True,
         )
         return call_string
 
@@ -313,10 +349,30 @@ def simple(project):
 
     current_uri = request_fullpath(request)
 
+    accept_header = request.headers.get("Accept", "")
+    wants_json = False
+    for media_type in PEP_691_JSON_ACCEPT_TYPES:
+        if media_type in accept_header:
+            wants_json = True
+            break
+    if wants_json:
+        files = []
+        for package in packages:
+            files.append(simple_project_file_json(current_uri, package))
+        response.content_type = PEP_691_JSON_CONTENT_TYPE
+        return dumps(
+            {
+                "meta": {"api-version": "1.4"},
+                "name": project,
+                "files": files,
+                "versions": simple_project_versions(packages),
+            }
+        )
+
     links = (
         (
             os.path.basename(pkg.relfn),
-            urljoin(current_uri, f"../../packages/{pkg.fname_and_hash}"),
+            simple_project_url(current_uri, pkg),
         )
         for pkg in packages
     )
@@ -348,9 +404,9 @@ def list_packages():
         key=lambda x: (os.path.dirname(x.relfn), x.pkgname, x.parsed_version),
     )
 
-    links = (
-        (pkg.relfn_unix, urljoin(fp, pkg.fname_and_hash)) for pkg in packages
-    )
+    links = []
+    for pkg in packages:
+        links.append((pkg.relfn_unix, urljoin(fp, pkg.fname_and_hash)))
 
     tmpl = """<!DOCTYPE html>
 <html lang="en">
@@ -383,9 +439,7 @@ def server_static(filename):
                 mimetype=mimetypes.guess_type(filename)[0],
             )
             if config.cache_control:
-                response.set_header(
-                    "Cache-Control", f"public, max-age={config.cache_control}"
-                )
+                response.set_header("Cache-Control", f"public, max-age={config.cache_control}")
             return response
 
     return HTTPError(404, f"Not Found ({filename} does not exist)\n\n")
@@ -412,9 +466,8 @@ def json_info(project):
     releases = defaultdict(list)
     req_url = request.url
     for x in packages:
-        releases[x.version].append(
-            {"url": urljoin(req_url, "../../packages/" + x.relfn)}
-        )
+        package_url = urljoin(req_url, "../../packages/" + x.relfn)
+        releases[x.version].append({"url": package_url})
 
     rv = {"info": {"version": latest_version}, "releases": releases}
     response.content_type = "application/json"

--- a/pypiserver/_app.py
+++ b/pypiserver/_app.py
@@ -194,10 +194,9 @@ Upload = namedtuple("Upload", "pkg sig")
 
 
 def file_upload():
-    files_get = getattr(request.files, "get")
-    package_file = files_get("content", None)
-    signature_file = files_get("gpg_signature", None)
-    ufiles = Upload(package_file, signature_file)
+    ufiles = Upload._make(
+        request.files.get(f, None) for f in ("content", "gpg_signature")
+    )
     if not ufiles.pkg:
         raise HTTPError(400, "Missing 'content' file-field!")
     signature_name = f"{ufiles.pkg.raw_filename}.asc"
@@ -210,9 +209,10 @@ def file_upload():
     for uf in ufiles:
         if not uf:
             continue
-        invalid_name = not is_valid_pkg_filename(uf.raw_filename)
-        unknown_package = guess_pkgname_and_version(uf.raw_filename) is None
-        if invalid_name or unknown_package:
+        if (
+            not is_valid_pkg_filename(uf.raw_filename)
+            or guess_pkgname_and_version(uf.raw_filename) is None
+        ):
             raise HTTPError(400, f"Bad filename: {uf.raw_filename}")
 
         if not config.overwrite and config.backend.exists(uf.raw_filename):
@@ -228,11 +228,10 @@ def file_upload():
             if "twine" in request.headers.get("User-Agent", ""):
                 http_code = 400
 
-            overwrite_msg = f"Package {uf.raw_filename!r} already exists!\n"
-            overwrite_msg += "  You may start server with `--overwrite` option."
             raise HTTPError(
                 http_code,
-                overwrite_msg,
+                f"Package {uf.raw_filename!r} already exists!\n"
+                "  You may start server with `--overwrite` option.",
             )
 
         config.backend.add_package(uf.raw_filename, uf.file)
@@ -288,8 +287,11 @@ def handle_rpc():
     )
     log.debug(f"Processing RPC2 request for '{methodname}'")
     if methodname == "search":
-        string_node = parser.getElementsByTagName("string")[0]
-        value = string_node.childNodes[0].wholeText.strip()
+        value = (
+            parser.getElementsByTagName("string")[0]
+            .childNodes[0]
+            .wholeText.strip()
+        )
         response = []
         ordering = 0
         for p in config.backend.get_all_packages():
@@ -353,22 +355,19 @@ def simple(project):
 
     current_uri = request_fullpath(request)
 
-    accept_header = request.headers.get("Accept", "")
-    wants_json = False
-    for media_type in PEP_691_JSON_ACCEPT_TYPES:
-        if media_type in accept_header:
-            wants_json = True
-            break
-    if wants_json:
-        files = []
-        for package in packages:
-            files.append(simple_project_file_json(current_uri, package))
+    if any(
+        media_type in request.headers.get("Accept", "")
+        for media_type in PEP_691_JSON_ACCEPT_TYPES
+    ):
         response.content_type = PEP_691_JSON_CONTENT_TYPE
         return dumps(
             {
                 "meta": {"api-version": "1.4"},
                 "name": project,
-                "files": files,
+                "files": [
+                    simple_project_file_json(current_uri, package)
+                    for package in packages
+                ],
                 "versions": simple_project_versions(packages),
             }
         )
@@ -408,9 +407,9 @@ def list_packages():
         key=lambda x: (os.path.dirname(x.relfn), x.pkgname, x.parsed_version),
     )
 
-    links = []
-    for pkg in packages:
-        links.append((pkg.relfn_unix, urljoin(fp, pkg.fname_and_hash)))
+    links = (
+        (pkg.relfn_unix, urljoin(fp, pkg.fname_and_hash)) for pkg in packages
+    )
 
     tmpl = """<!DOCTYPE html>
 <html lang="en">
@@ -473,8 +472,9 @@ def json_info(project):
     releases = defaultdict(list)
     req_url = request.url
     for x in packages:
-        package_url = urljoin(req_url, "../../packages/" + x.relfn)
-        releases[x.version].append({"url": package_url})
+        releases[x.version].append(
+            {"url": urljoin(req_url, "../../packages/" + x.relfn)}
+        )
 
     rv = {"info": {"version": latest_version}, "releases": releases}
     response.content_type = "application/json"

--- a/pypiserver/backend.py
+++ b/pypiserver/backend.py
@@ -127,10 +127,7 @@ class Backend(IBackend, abc.ABC):
         Backend class, either use this method as is, or override it with a
         more performant version.
         """
-        normalized_project = normalize_pkgname(project)
-        for package in self.get_all_packages():
-            if normalized_project == package.pkgname_norm:
-                yield package
+        return (x for x in self.get_all_packages() if normalize_pkgname(project) == x.pkgname_norm)
 
     def find_version(self, name: str, version: str) -> t.Iterable[PkgFile]:
         """Return all packages that match PkgFile.pkgname == name and
@@ -174,11 +171,7 @@ class SimpleFileBackend(Backend):
                 raise
 
     def exists(self, filename: str) -> bool:
-        for root in self.roots:
-            for existing_file in all_listed_files(root):
-                if filename == existing_file.name:
-                    return True
-        return False
+        return any(filename == existing_file.name for root in self.roots for existing_file in all_listed_files(root))
 
 
 class CachingFileBackend(SimpleFileBackend):
@@ -201,8 +194,7 @@ class CachingFileBackend(SimpleFileBackend):
         self.cache_manager.invalidate_root_cache(pkg.root)
 
     def get_all_packages(self) -> t.Iterable[PkgFile]:
-        for root in self.roots:
-            yield from self.cache_manager.listdir(root, listdir)
+        return itertools.chain.from_iterable(self.cache_manager.listdir(r, listdir) for r in self.roots)
 
     def digest(self, pkg: PkgFile) -> t.Optional[str]:
         if self.hash_algo is None or pkg.fn is None:
@@ -237,11 +229,7 @@ def listdir(root: Path) -> t.Iterator[PkgFile]:
 
 def all_listed_files(root: Path) -> t.Iterator[Path]:
     for dirpath, dirnames, filenames in os.walk(root):
-        listed_dirnames = []
-        for dirname in dirnames:
-            if is_listed_path(Path(dirname)):
-                listed_dirnames.append(dirname)
-        dirnames[:] = listed_dirnames
+        dirnames[:] = (dirname for dirname in dirnames if is_listed_path(Path(dirname)))
         for filename in filenames:
             if not is_listed_path(Path(filename)):
                 continue

--- a/pypiserver/backend.py
+++ b/pypiserver/backend.py
@@ -5,6 +5,7 @@ import itertools
 import logging
 import os
 import typing as t
+from datetime import UTC, datetime
 from pathlib import Path
 
 from .cache import ENABLE_CACHING, CacheManager
@@ -13,6 +14,12 @@ from .pkg_helpers import (
     guess_pkgname_and_version,
     is_listed_path,
     normalize_pkgname,
+)
+from .upload_time import (
+    fallback_upload_time,
+    load_upload_times,
+    normalize_upload_time_key,
+    save_upload_times,
 )
 
 if t.TYPE_CHECKING:
@@ -120,11 +127,10 @@ class Backend(IBackend, abc.ABC):
         Backend class, either use this method as is, or override it with a
         more performant version.
         """
-        return (
-            x
-            for x in self.get_all_packages()
-            if normalize_pkgname(project) == x.pkgname_norm
-        )
+        normalized_project = normalize_pkgname(project)
+        for package in self.get_all_packages():
+            if normalized_project == package.pkgname_norm:
+                yield package
 
     def find_version(self, name: str, version: str) -> t.Iterable[PkgFile]:
         """Return all packages that match PkgFile.pkgname == name and
@@ -147,7 +153,12 @@ class SimpleFileBackend(Backend):
         return itertools.chain.from_iterable(listdir(r) for r in self.roots)
 
     def add_package(self, filename: str, stream: t.BinaryIO) -> None:
-        write_file(stream, self.roots[0].joinpath(filename))
+        package_path = self.roots[0].joinpath(filename)
+        write_file(stream, package_path)
+        upload_times = load_upload_times(self.roots[0])
+        upload_time_key = normalize_upload_time_key(self.roots[0], package_path)
+        upload_times[upload_time_key] = datetime.now(UTC)
+        save_upload_times(self.roots[0], upload_times)
 
     def remove_package(self, pkg: PkgFile) -> None:
         if pkg.fn is not None:
@@ -155,18 +166,19 @@ class SimpleFileBackend(Backend):
                 os.remove(pkg.fn)
             except FileNotFoundError:
                 log.warning(
-                    "Tried to remove %s, but it is already gone", pkg.fn
+                    "Tried to remove %s, but it is already gone",
+                    pkg.fn,
                 )
             except OSError:
                 log.exception("Unexpected error removing package: %s", pkg.fn)
                 raise
 
     def exists(self, filename: str) -> bool:
-        return any(
-            filename == existing_file.name
-            for root in self.roots
-            for existing_file in all_listed_files(root)
-        )
+        for root in self.roots:
+            for existing_file in all_listed_files(root):
+                if filename == existing_file.name:
+                    return True
+        return False
 
 
 class CachingFileBackend(SimpleFileBackend):
@@ -185,18 +197,20 @@ class CachingFileBackend(SimpleFileBackend):
 
     def remove_package(self, pkg: PkgFile) -> None:
         super().remove_package(pkg)
+        assert pkg.root is not None
         self.cache_manager.invalidate_root_cache(pkg.root)
 
     def get_all_packages(self) -> t.Iterable[PkgFile]:
-        return itertools.chain.from_iterable(
-            self.cache_manager.listdir(r, listdir) for r in self.roots
-        )
+        for root in self.roots:
+            yield from self.cache_manager.listdir(root, listdir)
 
     def digest(self, pkg: PkgFile) -> t.Optional[str]:
         if self.hash_algo is None or pkg.fn is None:
             return None
         return self.cache_manager.digest_file(
-            pkg.fn, self.hash_algo, digest_file
+            pkg.fn,
+            self.hash_algo,
+            digest_file,
         )
 
 
@@ -217,14 +231,17 @@ def write_file(fh: t.BinaryIO, destination: PathLike) -> None:
 def listdir(root: Path) -> t.Iterator[PkgFile]:
     root = root.resolve()
     files = all_listed_files(root)
-    yield from valid_packages(root, files)
+    upload_times = load_upload_times(root)
+    yield from valid_packages(root, files, upload_times)
 
 
 def all_listed_files(root: Path) -> t.Iterator[Path]:
     for dirpath, dirnames, filenames in os.walk(root):
-        dirnames[:] = (
-            dirname for dirname in dirnames if is_listed_path(Path(dirname))
-        )
+        listed_dirnames = []
+        for dirname in dirnames:
+            if is_listed_path(Path(dirname)):
+                listed_dirnames.append(dirname)
+        dirnames[:] = listed_dirnames
         for filename in filenames:
             if not is_listed_path(Path(filename)):
                 continue
@@ -233,19 +250,26 @@ def all_listed_files(root: Path) -> t.Iterator[Path]:
                 yield filepath
 
 
-def valid_packages(root: Path, files: t.Iterable[Path]) -> t.Iterator[PkgFile]:
+def valid_packages(
+    root: Path,
+    files: t.Iterable[Path],
+    upload_times: dict[str, datetime],
+) -> t.Iterator[PkgFile]:
     for file in files:
         res = guess_pkgname_and_version(str(file.name))
         if res is not None:
             pkgname, version = res
             fn = str(file)
             root_name = str(root)
+            relfn = file.relative_to(root).as_posix()
+            upload_time = upload_times.get(relfn) or fallback_upload_time(file)
             yield PkgFile(
                 pkgname=pkgname,
                 version=version,
                 fn=fn,
                 root=root_name,
-                relfn=fn[len(root_name) + 1 :],
+                relfn=relfn,
+                upload_time=upload_time,
             )
 
 
@@ -279,7 +303,9 @@ PkgFunc = t.TypeVar("PkgFunc", bound=t.Callable[..., t.Iterable[PkgFile]])
 def with_digester(func: PkgFunc) -> PkgFunc:
     @functools.wraps(func)
     def add_digester_method(
-        self: "BackendProxy", *args: t.Any, **kwargs: t.Any
+        self: "BackendProxy",
+        *args: t.Any,
+        **kwargs: t.Any,
     ) -> t.Iterable[PkgFile]:
         packages = func(self, *args, **kwargs)
         for package in packages:

--- a/pypiserver/backend.py
+++ b/pypiserver/backend.py
@@ -170,6 +170,15 @@ class SimpleFileBackend(Backend):
                 log.exception("Unexpected error removing package: %s", pkg.fn)
                 raise
 
+        if pkg.root is None or pkg.relfn is None:
+            return
+
+        upload_root = Path(pkg.root)
+        upload_times = load_upload_times(upload_root)
+        if pkg.relfn in upload_times:
+            upload_times.pop(pkg.relfn)
+            save_upload_times(upload_root, upload_times)
+
     def exists(self, filename: str) -> bool:
         return any(filename == existing_file.name for root in self.roots for existing_file in all_listed_files(root))
 

--- a/pypiserver/backend.py
+++ b/pypiserver/backend.py
@@ -179,8 +179,7 @@ class SimpleFileBackend(Backend):
 
         upload_root = Path(pkg.root)
         upload_times = load_upload_times(upload_root)
-        if pkg.relfn in upload_times:
-            upload_times.pop(pkg.relfn)
+        if upload_times.pop(pkg.relfn, None) is not None:
             save_upload_times(upload_root, upload_times)
 
     def exists(self, filename: str) -> bool:

--- a/pypiserver/backend.py
+++ b/pypiserver/backend.py
@@ -127,7 +127,11 @@ class Backend(IBackend, abc.ABC):
         Backend class, either use this method as is, or override it with a
         more performant version.
         """
-        return (x for x in self.get_all_packages() if normalize_pkgname(project) == x.pkgname_norm)
+        return (
+            x
+            for x in self.get_all_packages()
+            if normalize_pkgname(project) == x.pkgname_norm
+        )
 
     def find_version(self, name: str, version: str) -> t.Iterable[PkgFile]:
         """Return all packages that match PkgFile.pkgname == name and
@@ -180,7 +184,11 @@ class SimpleFileBackend(Backend):
             save_upload_times(upload_root, upload_times)
 
     def exists(self, filename: str) -> bool:
-        return any(filename == existing_file.name for root in self.roots for existing_file in all_listed_files(root))
+        return any(
+            filename == existing_file.name
+            for root in self.roots
+            for existing_file in all_listed_files(root)
+        )
 
 
 class CachingFileBackend(SimpleFileBackend):
@@ -203,7 +211,9 @@ class CachingFileBackend(SimpleFileBackend):
         self.cache_manager.invalidate_root_cache(pkg.root)
 
     def get_all_packages(self) -> t.Iterable[PkgFile]:
-        return itertools.chain.from_iterable(self.cache_manager.listdir(r, listdir) for r in self.roots)
+        return itertools.chain.from_iterable(
+            self.cache_manager.listdir(r, listdir) for r in self.roots
+        )
 
     def digest(self, pkg: PkgFile) -> t.Optional[str]:
         if self.hash_algo is None or pkg.fn is None:
@@ -238,7 +248,9 @@ def listdir(root: Path) -> t.Iterator[PkgFile]:
 
 def all_listed_files(root: Path) -> t.Iterator[Path]:
     for dirpath, dirnames, filenames in os.walk(root):
-        dirnames[:] = (dirname for dirname in dirnames if is_listed_path(Path(dirname)))
+        dirnames[:] = (
+            dirname for dirname in dirnames if is_listed_path(Path(dirname))
+        )
         for filename in filenames:
             if not is_listed_path(Path(filename)):
                 continue

--- a/pypiserver/core.py
+++ b/pypiserver/core.py
@@ -57,13 +57,9 @@ class PkgFile:
         self.upload_time = upload_time
 
     def __repr__(self) -> str:
-        parts = []
-        for key in sorted(self.__slots__):
-            parts.append(f"{key}={getattr(self, key, 'AttributeError')!r}")
-        attributes = ", ".join(parts)
         return "{}({})".format(
             self.__class__.__name__,
-            attributes,
+            ", ".join([f"{k}={getattr(self, k, 'AttributeError')!r}" for k in sorted(self.__slots__)]),
         )
 
     @property

--- a/pypiserver/core.py
+++ b/pypiserver/core.py
@@ -1,6 +1,7 @@
 #! /usr/bin/env python3
 """minimal PyPI like server for use with pip/easy_install"""
 
+from datetime import datetime
 import mimetypes
 import typing as t
 
@@ -24,11 +25,13 @@ class PkgFile:
         "relfn_unix",  # The relative file path in unix notation
         "parsed_version",  # The package version as a tuple of parts
         "digester",  # a function that calculates the digest for the package
+        "upload_time",
     ]
     digest: t.Optional[str]
     digester: t.Optional[t.Callable[["PkgFile"], t.Optional[str]]]
     parsed_version: tuple
     relfn_unix: t.Optional[str]
+    upload_time: t.Optional[datetime]
 
     def __init__(
         self,
@@ -38,6 +41,7 @@ class PkgFile:
         root: t.Optional[str] = None,
         relfn: t.Optional[str] = None,
         replaces: t.Optional["PkgFile"] = None,
+        upload_time: t.Optional[datetime] = None,
     ):
         self.pkgname = pkgname
         self.pkgname_norm = normalize_pkgname(pkgname)
@@ -50,16 +54,16 @@ class PkgFile:
         self.replaces = replaces
         self.digest = None
         self.digester = None
+        self.upload_time = upload_time
 
     def __repr__(self) -> str:
+        parts = []
+        for key in sorted(self.__slots__):
+            parts.append(f"{key}={getattr(self, key, 'AttributeError')!r}")
+        attributes = ", ".join(parts)
         return "{}({})".format(
             self.__class__.__name__,
-            ", ".join(
-                [
-                    f"{k}={getattr(self, k, 'AttributeError')!r}"
-                    for k in sorted(self.__slots__)
-                ]
-            ),
+            attributes,
         )
 
     @property

--- a/pypiserver/core.py
+++ b/pypiserver/core.py
@@ -1,9 +1,9 @@
 #! /usr/bin/env python3
 """minimal PyPI like server for use with pip/easy_install"""
 
-from datetime import datetime
 import mimetypes
 import typing as t
+from datetime import datetime
 
 from pypiserver.pkg_helpers import normalize_pkgname, parse_version
 
@@ -59,7 +59,12 @@ class PkgFile:
     def __repr__(self) -> str:
         return "{}({})".format(
             self.__class__.__name__,
-            ", ".join([f"{k}={getattr(self, k, 'AttributeError')!r}" for k in sorted(self.__slots__)]),
+            ", ".join(
+                [
+                    f"{k}={getattr(self, k, 'AttributeError')!r}"
+                    for k in sorted(self.__slots__)
+                ]
+            ),
         )
 
     @property

--- a/pypiserver/upload_time.py
+++ b/pypiserver/upload_time.py
@@ -1,0 +1,87 @@
+from __future__ import annotations
+
+import json
+import logging
+import os
+import tempfile
+from datetime import UTC, datetime
+from pathlib import Path
+
+
+logger = logging.getLogger(__name__)
+
+SIDECAR_NAME = ".pypiserver-upload-times.json"
+
+
+def sidecar_path(root: Path) -> Path:
+    return Path(root) / SIDECAR_NAME
+
+
+def normalize_upload_time_key(root: Path, package_path: Path) -> str:
+    resolved_package = Path(package_path).resolve()
+    resolved_root = Path(root).resolve()
+    return resolved_package.relative_to(resolved_root).as_posix()
+
+
+def format_upload_time(value: datetime) -> str:
+    return value.astimezone(UTC).isoformat().replace("+00:00", "Z")
+
+
+def parse_upload_time(value: str) -> datetime:
+    return datetime.fromisoformat(value.replace("Z", "+00:00")).astimezone(UTC)
+
+
+def load_upload_times(root: Path) -> dict[str, datetime]:
+    path = sidecar_path(root)
+    if not path.exists():
+        return {}
+
+    try:
+        raw = json.loads(path.read_text(encoding="utf-8"))
+        if not isinstance(raw, dict):
+            raise ValueError("sidecar metadata must be a JSON object")
+        parsed = {}
+        for key, value in raw.items():
+            parsed[str(key)] = parse_upload_time(str(value))
+        return parsed
+    except (OSError, ValueError, TypeError, json.JSONDecodeError) as exc:
+        logger.warning(
+            "Failed to read upload-time metadata from %s: %s",
+            path,
+            exc,
+        )
+        return {}
+
+
+def save_upload_times(root: Path, metadata: dict[str, datetime]) -> None:
+    root = Path(root)
+    path = sidecar_path(root)
+    formatted = {}
+    for key, value in sorted(metadata.items()):
+        formatted[key] = format_upload_time(value)
+    serialized = json.dumps(
+        formatted,
+        indent=2,
+        sort_keys=True,
+    )
+
+    fd, tmp_name = tempfile.mkstemp(
+        prefix=f"{SIDECAR_NAME}.",
+        dir=root,
+        text=True,
+    )
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as fh:
+            fh.write(serialized)
+            fh.write("\n")
+        os.replace(tmp_name, path)
+    except Exception:
+        try:
+            os.unlink(tmp_name)
+        except FileNotFoundError:
+            pass
+        raise
+
+
+def fallback_upload_time(package_path: Path) -> datetime:
+    return datetime.fromtimestamp(Path(package_path).stat().st_mtime, tz=UTC)

--- a/pypiserver/upload_time.py
+++ b/pypiserver/upload_time.py
@@ -56,6 +56,13 @@ def load_upload_times(root: Path) -> dict[str, datetime]:
 def save_upload_times(root: Path, metadata: dict[str, datetime]) -> None:
     root = Path(root)
     path = sidecar_path(root)
+    if not metadata:
+        try:
+            path.unlink()
+        except FileNotFoundError:
+            pass
+        return
+
     formatted = {}
     for key, value in sorted(metadata.items()):
         formatted[key] = format_upload_time(value)

--- a/pypiserver/upload_time.py
+++ b/pypiserver/upload_time.py
@@ -7,7 +7,6 @@ import tempfile
 from datetime import UTC, datetime
 from pathlib import Path
 
-
 logger = logging.getLogger(__name__)
 
 SIDECAR_NAME = ".pypiserver-upload-times.json"

--- a/pypiserver/upload_time.py
+++ b/pypiserver/upload_time.py
@@ -39,10 +39,10 @@ def load_upload_times(root: Path) -> dict[str, datetime]:
         raw = json.loads(path.read_text(encoding="utf-8"))
         if not isinstance(raw, dict):
             raise ValueError("sidecar metadata must be a JSON object")
-        parsed = {}
-        for key, value in raw.items():
-            parsed[str(key)] = parse_upload_time(str(value))
-        return parsed
+        return {
+            str(key): parse_upload_time(str(value))
+            for key, value in raw.items()
+        }
     except (OSError, ValueError, TypeError, json.JSONDecodeError) as exc:
         logger.warning(
             "Failed to read upload-time metadata from %s: %s",
@@ -62,11 +62,8 @@ def save_upload_times(root: Path, metadata: dict[str, datetime]) -> None:
             pass
         return
 
-    formatted = {}
-    for key, value in sorted(metadata.items()):
-        formatted[key] = format_upload_time(value)
     serialized = json.dumps(
-        formatted,
+        {key: format_upload_time(value) for key, value in metadata.items()},
         indent=2,
         sort_keys=True,
     )

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -1,7 +1,6 @@
 #! /usr/bin/env py.test
 
 # Builtin imports
-import os
 import pathlib
 import xmlrpc.client as xmlrpclib
 from html import unescape
@@ -10,10 +9,11 @@ from html import unescape
 import pytest
 import webtest
 
+from pypiserver import __main__, _app, bottle_wrapper
+from pypiserver.backend import CachingFileBackend
+
 # Local Imports
 from tests.test_pkg_helpers import files, invalid_files
-from pypiserver import __main__, bottle_wrapper, _app
-from pypiserver.backend import CachingFileBackend
 
 # Enable logging to detect any problems with it
 ##

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -115,6 +115,14 @@ def add_file_to_root(app):
     return file_adder
 
 
+def listed_root_entries(root):
+    entries = []
+    for entry in root.listdir():
+        if not entry.basename.startswith("."):
+            entries.append(entry.basename)
+    return entries
+
+
 def test_root_count(root, testapp, add_file_to_root):
     """Test that the welcome page count updates with added packages
 
@@ -130,9 +138,7 @@ def test_root_count(root, testapp, add_file_to_root):
 
 def test_root_hostname(testapp):
     resp = testapp.get("/", headers={"Host": "systemexit.de"})
-    resp.mustcontain(
-        "easy_install --index-url http://systemexit.de/simple/ PACKAGE"
-    )
+    resp.mustcontain("easy_install --index-url http://systemexit.de/simple/ PACKAGE")
     # go("http://systemexit.de/")
 
 
@@ -336,24 +342,18 @@ def test_simple_index_case(root, testapp):
 
 def test_nonroot_root(testpriv):
     resp = testpriv.get("/priv/", headers={"Host": "nonroot"})
-    resp.mustcontain(
-        "easy_install --index-url http://nonroot/priv/simple/ PACKAGE"
-    )
+    resp.mustcontain("easy_install --index-url http://nonroot/priv/simple/ PACKAGE")
 
 
 def test_nonroot_root_with_x_forwarded_host(testapp):
     resp = testapp.get("/", headers={"X-Forwarded-Host": "forward.ed/priv/"})
-    resp.mustcontain(
-        "easy_install --index-url http://forward.ed/priv/simple/ PACKAGE"
-    )
+    resp.mustcontain("easy_install --index-url http://forward.ed/priv/simple/ PACKAGE")
     resp.mustcontain("""<a href="/priv/packages/">here</a>""")
 
 
 def test_nonroot_root_with_x_forwarded_host_without_trailing_slash(testapp):
     resp = testapp.get("/", headers={"X-Forwarded-Host": "forward.ed/priv"})
-    resp.mustcontain(
-        "easy_install --index-url http://forward.ed/priv/simple/ PACKAGE"
-    )
+    resp.mustcontain("easy_install --index-url http://forward.ed/priv/simple/ PACKAGE")
     resp.mustcontain("""<a href="/priv/packages/">here</a>""")
 
 
@@ -365,13 +365,12 @@ def test_nonroot_simple_index(root, testpriv, add_file_to_root):
     assert links[0]["href"].startswith("/priv/packages/foobar-1.0.zip#")
 
 
-def test_nonroot_simple_index_with_x_forwarded_host(
-    root, testapp, add_file_to_root
-):
+def test_nonroot_simple_index_with_x_forwarded_host(root, testapp, add_file_to_root):
     add_file_to_root(root, "foobar-1.0.zip", "123")
 
     resp = testapp.get(
-        "/simple/foobar/", headers={"X-Forwarded-Host": "forwarded.ed/priv/"}
+        "/simple/foobar/",
+        headers={"X-Forwarded-Host": "forwarded.ed/priv/"},
     )
     links = resp.html("a")
     assert len(links) == 1
@@ -386,13 +385,12 @@ def test_nonroot_simple_packages(root, testpriv, add_file_to_root):
     assert "/priv/packages/foobar-1.0.zip#" in links[0]["href"]
 
 
-def test_nonroot_simple_packages_with_x_forwarded_host(
-    root, testapp, add_file_to_root
-):
+def test_nonroot_simple_packages_with_x_forwarded_host(root, testapp, add_file_to_root):
     add_file_to_root(root, "foobar-1.0.zip", "123")
 
     resp = testapp.get(
-        "/packages/", headers={"X-Forwarded-Host": "forwarded/priv/"}
+        "/packages/",
+        headers={"X-Forwarded-Host": "forwarded/priv/"},
     )
     links = resp.html("a")
     assert len(links) == 1
@@ -512,9 +510,7 @@ def test_upload_badAction(testapp):
     assert "Unsupported ':action' field: BAD" in unescape(resp.text)
 
 
-@pytest.mark.parametrize(
-    "package", [f[0] for f in files if f[1] and "/" not in f[0]]
-)
+@pytest.mark.parametrize("package", [f[0] for f in files if f[1] and "/" not in f[0]])
 def test_upload(package, root, testapp):
     resp = testapp.post(
         "/",
@@ -522,7 +518,7 @@ def test_upload(package, root, testapp):
         upload_files=[("content", package, b"")],
     )
     assert resp.status_int == 200
-    uploaded_pkgs = [f.basename for f in root.listdir()]
+    uploaded_pkgs = listed_root_entries(root)
     assert len(uploaded_pkgs) == 1
     assert uploaded_pkgs[0].lower() == package.lower()
 
@@ -557,9 +553,7 @@ def test_upload_conflict_on_existing_for_twine_compatibility(root, testapp):
     assert "Package 'foo_bar-1.0.tar.gz' already exists!" in unescape(resp.text)
 
 
-@pytest.mark.parametrize(
-    "package", [f[0] for f in files if f[1] and "/" not in f[0]]
-)
+@pytest.mark.parametrize("package", [f[0] for f in files if f[1] and "/" not in f[0]])
 def test_upload_with_signature(package, root, testapp):
     resp = testapp.post(
         "/",
@@ -570,7 +564,7 @@ def test_upload_with_signature(package, root, testapp):
         ],
     )
     assert resp.status_int == 200
-    uploaded_pkgs = [f.basename.lower() for f in root.listdir()]
+    uploaded_pkgs = [basename.lower() for basename in listed_root_entries(root)]
     assert len(uploaded_pkgs) == 2
     assert package.lower() in uploaded_pkgs
     assert f"{package.lower()}.asc" in uploaded_pkgs
@@ -698,10 +692,10 @@ class TestRemovePkg:
     def test_remove_pkg(self, root, testapp, pkg, name, ver):
         """Packages can be removed via POST."""
         root.join(pkg).write("")
-        assert len(os.listdir(str(root))) == 1
+        assert listed_root_entries(root) == [pkg]
         params = {":action": "remove_pkg", "name": name, "version": ver}
         testapp.post("/", params=params)
-        assert len(os.listdir(str(root))) == 0
+        assert listed_root_entries(root) == []
 
     @pytest.mark.parametrize(
         "pkg, name, ver",
@@ -720,15 +714,21 @@ class TestRemovePkg:
         ),
     )
     def test_remove_pkg_only_targeted(
-        self, root, testapp, pkg, name, ver, other
+        self,
+        root,
+        testapp,
+        pkg,
+        name,
+        ver,
+        other,
     ):
         """Only the targeted package is removed."""
         root.join(pkg).write("")
         root.join(other).write("")
-        assert len(os.listdir(str(root))) == 2
+        assert sorted(listed_root_entries(root)) == sorted([pkg, other])
         params = {":action": "remove_pkg", "name": name, "version": ver}
         testapp.post("/", params=params)
-        assert len(os.listdir(str(root))) == 1
+        assert listed_root_entries(root) == [other]
 
     @pytest.mark.parametrize(
         "pkgs, name, ver",
@@ -744,10 +744,10 @@ class TestRemovePkg:
         """Test that all instances of the target are removed."""
         for pkg in pkgs:
             root.join(pkg).write("")
-        assert len(os.listdir(str(root))) == len(pkgs)
+        assert sorted(listed_root_entries(root)) == sorted(pkgs)
         params = {":action": "remove_pkg", "name": name, "version": ver}
         testapp.post("/", params=params)
-        assert len(os.listdir(str(root))) == 0
+        assert listed_root_entries(root) == []
 
     @pytest.mark.parametrize(
         ("name", "version"),
@@ -783,8 +783,6 @@ class TestRemovePkg:
 def test_redirect_project_encodes_newlines():
     """Ensure raw newlines are url encoded in the generated redirect."""
     project = "\nSet-Cookie:malicious=1;"
-    request = bottle_wrapper.Request(
-        {"HTTP_X_FORWARDED_PROTO": "/\nSet-Cookie:malicious=1;"}
-    )
+    request = bottle_wrapper.Request({"HTTP_X_FORWARDED_PROTO": "/\nSet-Cookie:malicious=1;"})
     newpath = _app.get_bad_url_redirect_path(request, project)
     assert "\n" not in newpath

--- a/tests/test_backend.py
+++ b/tests/test_backend.py
@@ -1,16 +1,24 @@
+import io
+import typing as t
+from datetime import UTC, datetime
 from pathlib import Path
+from types import SimpleNamespace
 
 import pytest
 
-from pypiserver.backend import listdir
+from pypiserver.backend import (
+    SimpleFileBackend,
+    listdir,
+)
+from pypiserver.config import _ConfigCommon
+from pypiserver.upload_time import load_upload_times
 
 
 def create_path(root: Path, path: Path):
     if path.is_absolute():
-        raise ValueError(
-            "Only test using relative paths"
-            " to prevent leaking outside test environment"
-        )
+        msg = "Only test using relative paths to prevent leaking outside "
+        msg += "test environment"
+        raise ValueError(msg)
     fullpath = root / path
     if not fullpath.parent.exists():
         fullpath.parent.mkdir(parents=True)
@@ -40,3 +48,20 @@ def test_listdir_doesnt_generate_pkgfile_for_invalid_file(tmp_path, path_name):
     path = Path(path_name)
     create_path(tmp_path, path)
     assert not list(listdir(tmp_path))
+
+
+def make_backend_config(root: Path):
+    return t.cast(_ConfigCommon, SimpleNamespace(hash_algo=None, roots=[root]))
+
+
+def test_simple_backend_add_package_persists_upload_time_metadata(tmp_path):
+    backend = SimpleFileBackend(make_backend_config(tmp_path))
+
+    backend.add_package("demo-1.0.tar.gz", io.BytesIO(b"payload"))
+
+    assert (tmp_path / "demo-1.0.tar.gz").read_bytes() == b"payload"
+    metadata = load_upload_times(tmp_path)
+    assert set(metadata) == {"demo-1.0.tar.gz"}
+    delta = metadata["demo-1.0.tar.gz"] - datetime.now(UTC)
+    age_seconds = delta.total_seconds()
+    assert abs(age_seconds) < 2

--- a/tests/test_backend.py
+++ b/tests/test_backend.py
@@ -12,6 +12,7 @@ from pypiserver.backend import (
 )
 from pypiserver.config import _ConfigCommon
 from pypiserver.upload_time import load_upload_times
+from pypiserver.upload_time import SIDECAR_NAME
 
 
 def create_path(root: Path, path: Path):
@@ -65,3 +66,24 @@ def test_simple_backend_add_package_persists_upload_time_metadata(tmp_path):
     delta = metadata["demo-1.0.tar.gz"] - datetime.now(UTC)
     age_seconds = delta.total_seconds()
     assert abs(age_seconds) < 2
+
+
+def test_simple_backend_remove_package_updates_upload_time_metadata(tmp_path):
+    backend = SimpleFileBackend(make_backend_config(tmp_path))
+
+    backend.add_package("demo-1.0.tar.gz", io.BytesIO(b"demo"))
+    backend.add_package("other-2.0.tar.gz", io.BytesIO(b"other"))
+
+    packages = {pkg.relfn: pkg for pkg in backend.get_all_packages()}
+
+    backend.remove_package(packages["demo-1.0.tar.gz"])
+
+    assert not (tmp_path / "demo-1.0.tar.gz").exists()
+    assert set(load_upload_times(tmp_path)) == {"other-2.0.tar.gz"}
+    assert (tmp_path / SIDECAR_NAME).exists()
+
+    backend.remove_package(packages["other-2.0.tar.gz"])
+
+    assert not (tmp_path / "other-2.0.tar.gz").exists()
+    assert load_upload_times(tmp_path) == {}
+    assert not (tmp_path / SIDECAR_NAME).exists()

--- a/tests/test_backend.py
+++ b/tests/test_backend.py
@@ -11,8 +11,7 @@ from pypiserver.backend import (
     listdir,
 )
 from pypiserver.config import _ConfigCommon
-from pypiserver.upload_time import load_upload_times
-from pypiserver.upload_time import SIDECAR_NAME
+from pypiserver.upload_time import SIDECAR_NAME, load_upload_times
 
 
 def create_path(root: Path, path: Path):

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -13,8 +13,9 @@ The tests below are using 3 ways to startup pypi-servers:
 """
 
 import contextlib
-import itertools
+import json
 import os
+from datetime import UTC, datetime
 import shutil
 import socket
 import re
@@ -24,9 +25,9 @@ import typing as t
 from collections import namedtuple
 from pathlib import Path
 from shlex import split
-from subprocess import Popen
+from subprocess import PIPE, STDOUT, Popen
 from urllib.error import URLError
-from urllib.request import urlopen
+from urllib.request import Request, urlopen
 
 import pytest
 
@@ -36,16 +37,24 @@ import pytest
 
 
 CURRENT_PATH = Path(__file__).parent
-ports = itertools.count(10000)
 Srv = namedtuple("Srv", ("port", "root"))
 
 
+def reserve_port() -> int:
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
+        sock.bind(("127.0.0.1", 0))
+        sock.listen()
+        return t.cast(int, sock.getsockname()[1])
+
+
 @contextlib.contextmanager
-def run_server(root, authed=False, other_cli=""):
+def run_server(
+    root,
+    authed: bool | t.Literal["partial"] = False,
+    other_cli="",
+):
     """Run a server, optionally with partial auth enabled."""
-    htpasswd = (
-        CURRENT_PATH.joinpath("../fixtures/htpasswd.a.a").expanduser().resolve()
-    )
+    htpasswd = CURRENT_PATH.joinpath("../fixtures/htpasswd.a.a").expanduser().resolve()
     pswd_opt_choices = {
         True: f"-P {htpasswd} -a update,download",
         False: "-P. -a.",
@@ -53,17 +62,34 @@ def run_server(root, authed=False, other_cli=""):
     }
     pswd_opts = pswd_opt_choices[authed]
 
-    port = next(ports)
-    cmd = (
-        f"{sys.executable} -m pypiserver.__main__ "
-        f"run -vvv --overwrite -i 127.0.0.1 "
-        f"-p {port} {pswd_opts} {other_cli} {root}"
-    )
-    proc = Popen(cmd.split(), bufsize=2**16)
-    srv = Srv(port, root)
+    proc = None
+    srv = None
+    for _ in range(5):
+        port = reserve_port()
+        cmd = (
+            f"{sys.executable} -m pypiserver.__main__ "
+            f"run -vvv --overwrite -i 127.0.0.1 "
+            f"-p {port} {pswd_opts} {other_cli} {root}"
+        )
+        proc = Popen(cmd.split(), bufsize=2**16)
+        srv = Srv(port, root)
+        try:
+            wait_until_ready(srv)
+            if proc.poll() is None:
+                break
+        except TimeoutError:
+            pass
+        finally:
+            if proc.poll() is not None:
+                proc.wait()
+                proc = None
+    else:
+        raise TimeoutError("Failed to start test pypiserver")
+
+    assert proc is not None
+    assert srv is not None
+
     try:
-        wait_until_ready(srv)
-        assert proc.poll() is None
         yield srv
     finally:
         print(f"Killing {srv}")
@@ -149,10 +175,7 @@ def wheel_file(project, tmp_path_factory):
     if re.match(r"^3\.7", sys.version):
         assert run_setup_py(project, f"bdist_wheel -d {distdir}") == 0
     else:
-        assert (
-            run_py_build(project, f"--wheel --no-isolation --outdir {distdir}")
-            == 0
-        )
+        assert run_py_build(project, f"--wheel --no-isolation --outdir {distdir}") == 0
     wheels = list(distdir.glob("centodeps*.whl"))
     assert len(wheels) > 0
     return wheels[0]
@@ -226,10 +249,7 @@ def pip_download(
 
 
 def _run_pip(cmd: str) -> int:
-    ncmd = (
-        "pip --no-cache-dir --disable-pip-version-check "
-        f"--retries 0 --timeout 5 --no-input {cmd}"
-    )
+    ncmd = f"pip --no-cache-dir --disable-pip-version-check --retries 0 --timeout 5 --no-input {cmd}"
     print(f"PIP: {ncmd}")
     proc = Popen(split(ncmd))
     proc.communicate()
@@ -284,14 +304,119 @@ def authed_pypirc(authed_server):
         yield path
 
 
-def run_twine(command: str, package: str, conf: str) -> None:
-    proc = Popen(
-        split(
-            f"twine {command} --repository test --config-file {conf} {package}"
-        )
-    )
+def run_twine(
+    command: str,
+    package: str | Path,
+    conf: str | Path,
+) -> None:
+    cmd = f"twine {command} --repository test --config-file {conf} {package}"
+    proc = Popen(split(cmd))
     proc.communicate()
     assert not proc.returncode, f"Twine {command} failed. See stdout/err"
+
+
+def run_checked(args: list[str]) -> str:
+    print("RUN:", " ".join(args))
+    proc = Popen(args, stdout=PIPE, stderr=STDOUT, text=True)
+    stdout, _ = proc.communicate()
+    assert proc.returncode == 0, stdout
+    return stdout
+
+
+def build_dummy_wheel(tmp_path: Path, name: str, version: str) -> Path:
+    project_dir = tmp_path / version
+    dist_dir = tmp_path / "dist" / version
+    project_dir.mkdir(parents=True, exist_ok=True)
+    dist_dir.mkdir(parents=True, exist_ok=True)
+    project_dir.joinpath("setup.py").write_text(
+        "\n".join(
+            (
+                "from setuptools import setup",
+                "",
+                "setup(",
+                f"    name={name!r},",
+                f"    version={version!r},",
+                "    packages=[],",
+                ")",
+                "",
+            )
+        )
+    )
+    if re.match(r"^3\.7", sys.version):
+        assert run_setup_py(project_dir, f"bdist_wheel -d {dist_dir}") == 0
+    else:
+        flags = f"--wheel --no-isolation --outdir {dist_dir}"
+        assert run_py_build(project_dir, flags) == 0
+    wheels = list(dist_dir.glob("*.whl"))
+    assert len(wheels) == 1
+    return wheels[0]
+
+
+def load_simple_project_json(port: int, project: str) -> dict[str, t.Any]:
+    request = Request(
+        f"{build_url(port)}/simple/{project}/",
+        headers={"Accept": "application/vnd.pypi.simple.v1+json"},
+    )
+    with urlopen(request) as response:
+        assert response.getcode() == 200
+        return json.load(response)
+
+
+def parse_upload_time(value: str) -> datetime:
+    return datetime.fromisoformat(value.replace("Z", "+00:00"))
+
+
+def install_with_uv(
+    venv_dir: Path,
+    package: str,
+    index_url: str,
+    allow_host: str,
+    exclude_newer: str | None = None,
+) -> None:
+    uv_dir = str(venv_dir.parent)
+    run_checked(
+        [
+            "uv",
+            "--directory",
+            uv_dir,
+            "--no-config",
+            "venv",
+            str(venv_dir),
+            "--python",
+            sys.executable,
+        ]
+    )
+    args = [
+        "uv",
+        "--directory",
+        uv_dir,
+        "--no-config",
+        "pip",
+        "install",
+        "--no-cache",
+        "--python",
+        str(venv_dir),
+        "--index-url",
+        index_url,
+        "--allow-insecure-host",
+        allow_host,
+    ]
+    if exclude_newer is not None:
+        args.extend(["--exclude-newer", exclude_newer])
+    args.append(package)
+    run_checked(args)
+
+
+def installed_version(venv_dir: Path, package: str) -> str:
+    python = venv_dir / "bin" / "python"
+    cmd = f"import importlib.metadata as md; print(md.version({package!r}))"
+    return run_checked(
+        [
+            str(python),
+            "-c",
+            cmd,
+        ]
+    ).strip()
 
 
 # ######################################################################
@@ -322,12 +447,7 @@ def test_pip_install_authed_fails(authed_server, pipdir):
 
 
 def test_pip_install_authed_succeeds(authed_server, hosted_wheel_file, pipdir):
-    assert (
-        pip_download(
-            "centodeps", authed_server.port, pipdir, user="a", pswd="a"
-        )
-        == 0
-    )
+    assert pip_download("centodeps", authed_server.port, pipdir, user="a", pswd="a") == 0
     assert pipdir.joinpath(hosted_wheel_file.name).is_file()
 
 
@@ -342,16 +462,12 @@ def test_partial_authed_open_download(partial_authed_server):
 @pytest.mark.usefixtures("hosted_wheel_file")
 def test_hash_algos(server_root, pipdir, hash_algo):
     """Test twine upload with no authentication"""
-    with run_server(
-        server_root, other_cli="--hash-algo {}".format(hash_algo)
-    ) as srv:
+    with run_server(server_root, other_cli="--hash-algo {}".format(hash_algo)) as srv:
         assert pip_download("centodeps", srv.port, pipdir) == 0
 
 
 @pytest.mark.parametrize(["server_fixture", "pypirc_fixture"], all_servers)
-def test_twine_upload(
-    server_fixture, pypirc_fixture, server_root, wheel_file, request
-):
+def test_twine_upload(server_fixture, pypirc_fixture, server_root, wheel_file, request):
     """Test twine upload with no authentication"""
     assert len(list(server_root.iterdir())) == 0
     request.getfixturevalue(server_fixture)
@@ -359,10 +475,11 @@ def test_twine_upload(
 
     run_twine("upload", wheel_file, conf=pypirc)
 
-    assert len(list(server_root.iterdir())) == 1
+    package_files = [path for path in server_root.iterdir() if not path.name.startswith(".")]
+    assert len(package_files) == 1
     assert server_root.joinpath(wheel_file.name).is_file(), (
         wheel_file.name,
-        list(server_root.iterdir()),
+        package_files,
     )
 
 
@@ -372,3 +489,63 @@ def test_twine_register(server_fixture, pypirc_fixture, wheel_file, request):
     request.getfixturevalue(server_fixture)
     pypirc = request.getfixturevalue(pypirc_fixture)
     run_twine("register", wheel_file, conf=pypirc)
+
+
+def test_twine_upload_json_upload_times_drive_uv_exclude_newer(tmp_path):
+    package = "dummy-live-upload"
+    older_version = "1.0.0"
+    newer_version = "2.0.0"
+    older_wheel = build_dummy_wheel(tmp_path, package, older_version)
+    newer_wheel = build_dummy_wheel(tmp_path, package, newer_version)
+    server_root = tmp_path / "packages"
+    server_root.mkdir()
+
+    with run_server(server_root, other_cli="--disable-fallback") as upload_srv:
+        with pypirc_file(repo=build_url(upload_srv.port)) as pypirc:
+            run_twine("upload", older_wheel, conf=pypirc)
+            run_twine("upload", newer_wheel, conf=pypirc)
+
+    sidecar_path = server_root / ".pypiserver-upload-times.json"
+    assert sidecar_path.is_file()
+    stored_upload_times = json.loads(sidecar_path.read_text())
+    assert stored_upload_times[older_wheel.name] < stored_upload_times[newer_wheel.name]
+
+    older_uploaded = server_root / older_wheel.name
+    newer_uploaded = server_root / newer_wheel.name
+    os.utime(older_uploaded, (1700000200, 1700000200))
+    os.utime(newer_uploaded, (1700000100, 1700000100))
+
+    with run_server(server_root, other_cli="--disable-fallback") as install_srv:
+        body = load_simple_project_json(install_srv.port, package)
+        assert body["meta"] == {"api-version": "1.4"}
+        assert body["name"] == package
+        assert body["versions"] == [older_version, newer_version]
+        files_by_version = {
+            older_version: next(item for item in body["files"] if item["filename"] == older_wheel.name),
+            newer_version: next(item for item in body["files"] if item["filename"] == newer_wheel.name),
+        }
+        assert files_by_version[older_version]["upload-time"] == stored_upload_times[older_wheel.name]
+        assert files_by_version[newer_version]["upload-time"] == stored_upload_times[newer_wheel.name]
+        older_time = parse_upload_time(files_by_version[older_version]["upload-time"])
+        newer_time = parse_upload_time(files_by_version[newer_version]["upload-time"])
+        assert older_time.tzinfo == UTC
+        assert newer_time.tzinfo == UTC
+        assert older_time < newer_time
+        cutover = older_time + (newer_time - older_time) / 2
+        cutoff = cutover.isoformat().replace("+00:00", "Z")
+        index_url = f"{build_url(install_srv.port)}/simple/"
+        allow_host = f"localhost:{install_srv.port}"
+
+        strict_env = tmp_path / "strict-env"
+        install_with_uv(
+            strict_env,
+            package,
+            index_url,
+            allow_host,
+            exclude_newer=cutoff,
+        )
+        assert installed_version(strict_env, package) == older_version
+
+        open_env = tmp_path / "open-env"
+        install_with_uv(open_env, package, index_url, allow_host)
+        assert installed_version(open_env, package) == newer_version

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -462,12 +462,21 @@ def test_partial_authed_open_download(partial_authed_server):
 @pytest.mark.usefixtures("hosted_wheel_file")
 def test_hash_algos(server_root, pipdir, hash_algo):
     """Test twine upload with no authentication"""
-    with run_server(server_root, other_cli="--hash-algo {}".format(hash_algo)) as srv:
+    with run_server(
+        server_root,
+        other_cli="--hash-algo {}".format(hash_algo),
+    ) as srv:
         assert pip_download("centodeps", srv.port, pipdir) == 0
 
 
 @pytest.mark.parametrize(["server_fixture", "pypirc_fixture"], all_servers)
-def test_twine_upload(server_fixture, pypirc_fixture, server_root, wheel_file, request):
+def test_twine_upload(
+    server_fixture,
+    pypirc_fixture,
+    server_root,
+    wheel_file,
+    request,
+):
     """Test twine upload with no authentication"""
     assert len(list(server_root.iterdir())) == 0
     request.getfixturevalue(server_fixture)

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -310,7 +310,15 @@ def run_twine(
     conf: str | Path,
 ) -> None:
     run(
-        split(f"twine {command} --repository test --config-file {conf} {package}"),
+        [
+            "twine",
+            command,
+            "--repository",
+            "test",
+            "--config-file",
+            str(conf),
+            str(package),
+        ],
         check=True,
     )
 
@@ -460,7 +468,7 @@ def test_twine_upload_json_upload_times_drive_uv_exclude_newer(tmp_path):
             args.extend(["--exclude-newer", exclude_newer])
         args.append(package)
         run(args, check=True)
-        python = venv_dir / "bin" / "python"
+        python = venv_dir / ("Scripts/python.exe" if os.name == "nt" else "bin/python")
         cmd = f"import importlib.metadata as md; print(md.version({package!r}))"
         return run(
             [str(python), "-c", cmd],

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -412,14 +412,10 @@ def test_twine_upload_json_upload_times_drive_uv_exclude_newer(tmp_path):
             f"from setuptools import setup\n\n"
             f"setup(name={package!r}, version={version!r}, packages=[])\n"
         )
-        if re.match(r"^3\.7", sys.version):
-            exit_code = run_setup_py(project_dir, f"bdist_wheel -d {dist_dir}")
-        else:
-            exit_code = run_py_build(
-                project_dir,
-                f"--wheel --no-isolation --outdir {dist_dir}",
-            )
-        assert exit_code == 0
+        assert run_py_build(
+            project_dir,
+            f"--wheel --no-isolation --outdir {dist_dir}",
+        ) == 0
         wheels = list(dist_dir.glob("*.whl"))
         assert len(wheels) == 1
         return wheels[0]

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -505,6 +505,8 @@ def test_twine_upload_json_upload_times_drive_uv_exclude_newer(tmp_path):
         newer_file = files_by_name[newer_wheel.name]
         assert older_file["upload-time"] == stored_upload_times[older_wheel.name]
         assert newer_file["upload-time"] == stored_upload_times[newer_wheel.name]
+        assert older_file["size"] == older_uploaded.stat().st_size
+        assert newer_file["size"] == newer_uploaded.stat().st_size
         older_time = datetime.fromisoformat(
             older_file["upload-time"].replace("Z", "+00:00")
         )

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -15,14 +15,14 @@ The tests below are using 3 ways to startup pypi-servers:
 import contextlib
 import json
 import os
-from datetime import UTC, datetime
+import re
 import shutil
 import socket
-import re
 import sys
 import time
 import typing as t
 from collections import namedtuple
+from datetime import UTC, datetime
 from pathlib import Path
 from shlex import split
 from subprocess import Popen, run

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -25,7 +25,7 @@ import typing as t
 from collections import namedtuple
 from pathlib import Path
 from shlex import split
-from subprocess import PIPE, STDOUT, Popen
+from subprocess import Popen, run
 from urllib.error import URLError
 from urllib.request import Request, urlopen
 
@@ -309,114 +309,10 @@ def run_twine(
     package: str | Path,
     conf: str | Path,
 ) -> None:
-    cmd = f"twine {command} --repository test --config-file {conf} {package}"
-    proc = Popen(split(cmd))
-    proc.communicate()
-    assert not proc.returncode, f"Twine {command} failed. See stdout/err"
-
-
-def run_checked(args: list[str]) -> str:
-    print("RUN:", " ".join(args))
-    proc = Popen(args, stdout=PIPE, stderr=STDOUT, text=True)
-    stdout, _ = proc.communicate()
-    assert proc.returncode == 0, stdout
-    return stdout
-
-
-def build_dummy_wheel(tmp_path: Path, name: str, version: str) -> Path:
-    project_dir = tmp_path / version
-    dist_dir = tmp_path / "dist" / version
-    project_dir.mkdir(parents=True, exist_ok=True)
-    dist_dir.mkdir(parents=True, exist_ok=True)
-    project_dir.joinpath("setup.py").write_text(
-        "\n".join(
-            (
-                "from setuptools import setup",
-                "",
-                "setup(",
-                f"    name={name!r},",
-                f"    version={version!r},",
-                "    packages=[],",
-                ")",
-                "",
-            )
-        )
+    run(
+        split(f"twine {command} --repository test --config-file {conf} {package}"),
+        check=True,
     )
-    if re.match(r"^3\.7", sys.version):
-        assert run_setup_py(project_dir, f"bdist_wheel -d {dist_dir}") == 0
-    else:
-        flags = f"--wheel --no-isolation --outdir {dist_dir}"
-        assert run_py_build(project_dir, flags) == 0
-    wheels = list(dist_dir.glob("*.whl"))
-    assert len(wheels) == 1
-    return wheels[0]
-
-
-def load_simple_project_json(port: int, project: str) -> dict[str, t.Any]:
-    request = Request(
-        f"{build_url(port)}/simple/{project}/",
-        headers={"Accept": "application/vnd.pypi.simple.v1+json"},
-    )
-    with urlopen(request) as response:
-        assert response.getcode() == 200
-        return json.load(response)
-
-
-def parse_upload_time(value: str) -> datetime:
-    return datetime.fromisoformat(value.replace("Z", "+00:00"))
-
-
-def install_with_uv(
-    venv_dir: Path,
-    package: str,
-    index_url: str,
-    allow_host: str,
-    exclude_newer: str | None = None,
-) -> None:
-    uv_dir = str(venv_dir.parent)
-    run_checked(
-        [
-            "uv",
-            "--directory",
-            uv_dir,
-            "--no-config",
-            "venv",
-            str(venv_dir),
-            "--python",
-            sys.executable,
-        ]
-    )
-    args = [
-        "uv",
-        "--directory",
-        uv_dir,
-        "--no-config",
-        "pip",
-        "install",
-        "--no-cache",
-        "--python",
-        str(venv_dir),
-        "--index-url",
-        index_url,
-        "--allow-insecure-host",
-        allow_host,
-    ]
-    if exclude_newer is not None:
-        args.extend(["--exclude-newer", exclude_newer])
-    args.append(package)
-    run_checked(args)
-
-
-def installed_version(venv_dir: Path, package: str) -> str:
-    python = venv_dir / "bin" / "python"
-    cmd = f"import importlib.metadata as md; print(md.version({package!r}))"
-    return run_checked(
-        [
-            str(python),
-            "-c",
-            cmd,
-        ]
-    ).strip()
 
 
 # ######################################################################
@@ -484,7 +380,9 @@ def test_twine_upload(
 
     run_twine("upload", wheel_file, conf=pypirc)
 
-    package_files = [path for path in server_root.iterdir() if not path.name.startswith(".")]
+    package_files = [
+        path for path in server_root.iterdir() if not path.name.startswith(".")
+    ]
     assert len(package_files) == 1
     assert server_root.joinpath(wheel_file.name).is_file(), (
         wheel_file.name,
@@ -504,8 +402,79 @@ def test_twine_upload_json_upload_times_drive_uv_exclude_newer(tmp_path):
     package = "dummy-live-upload"
     older_version = "1.0.0"
     newer_version = "2.0.0"
-    older_wheel = build_dummy_wheel(tmp_path, package, older_version)
-    newer_wheel = build_dummy_wheel(tmp_path, package, newer_version)
+
+    def build_wheel(version: str) -> Path:
+        project_dir = tmp_path / version
+        dist_dir = tmp_path / "dist" / version
+        project_dir.mkdir(parents=True, exist_ok=True)
+        dist_dir.mkdir(parents=True, exist_ok=True)
+        project_dir.joinpath("setup.py").write_text(
+            f"from setuptools import setup\n\n"
+            f"setup(name={package!r}, version={version!r}, packages=[])\n"
+        )
+        if re.match(r"^3\.7", sys.version):
+            exit_code = run_setup_py(project_dir, f"bdist_wheel -d {dist_dir}")
+        else:
+            exit_code = run_py_build(
+                project_dir,
+                f"--wheel --no-isolation --outdir {dist_dir}",
+            )
+        assert exit_code == 0
+        wheels = list(dist_dir.glob("*.whl"))
+        assert len(wheels) == 1
+        return wheels[0]
+
+    def uv_install_version(
+        env_name: str,
+        index_url: str,
+        allow_host: str,
+        exclude_newer: str | None = None,
+    ) -> str:
+        venv_dir = tmp_path / env_name
+        uv_dir = str(venv_dir.parent)
+        run(
+            [
+                "uv",
+                "--directory",
+                uv_dir,
+                "--no-config",
+                "venv",
+                str(venv_dir),
+                "--python",
+                sys.executable,
+            ],
+            check=True,
+        )
+        args = [
+            "uv",
+            "--directory",
+            uv_dir,
+            "--no-config",
+            "pip",
+            "install",
+            "--no-cache",
+            "--python",
+            str(venv_dir),
+            "--index-url",
+            index_url,
+            "--allow-insecure-host",
+            allow_host,
+        ]
+        if exclude_newer is not None:
+            args.extend(["--exclude-newer", exclude_newer])
+        args.append(package)
+        run(args, check=True)
+        python = venv_dir / "bin" / "python"
+        cmd = f"import importlib.metadata as md; print(md.version({package!r}))"
+        return run(
+            [str(python), "-c", cmd],
+            check=True,
+            capture_output=True,
+            text=True,
+        ).stdout.strip()
+
+    older_wheel = build_wheel(older_version)
+    newer_wheel = build_wheel(newer_version)
     server_root = tmp_path / "packages"
     server_root.mkdir()
 
@@ -525,18 +494,27 @@ def test_twine_upload_json_upload_times_drive_uv_exclude_newer(tmp_path):
     os.utime(newer_uploaded, (1700000100, 1700000100))
 
     with run_server(server_root, other_cli="--disable-fallback") as install_srv:
-        body = load_simple_project_json(install_srv.port, package)
+        request = Request(
+            f"{build_url(install_srv.port)}/simple/{package}/",
+            headers={"Accept": "application/vnd.pypi.simple.v1+json"},
+        )
+        with urlopen(request) as response:
+            assert response.getcode() == 200
+            body = json.load(response)
         assert body["meta"] == {"api-version": "1.4"}
         assert body["name"] == package
         assert body["versions"] == [older_version, newer_version]
-        files_by_version = {
-            older_version: next(item for item in body["files"] if item["filename"] == older_wheel.name),
-            newer_version: next(item for item in body["files"] if item["filename"] == newer_wheel.name),
-        }
-        assert files_by_version[older_version]["upload-time"] == stored_upload_times[older_wheel.name]
-        assert files_by_version[newer_version]["upload-time"] == stored_upload_times[newer_wheel.name]
-        older_time = parse_upload_time(files_by_version[older_version]["upload-time"])
-        newer_time = parse_upload_time(files_by_version[newer_version]["upload-time"])
+        files_by_name = {item["filename"]: item for item in body["files"]}
+        older_file = files_by_name[older_wheel.name]
+        newer_file = files_by_name[newer_wheel.name]
+        assert older_file["upload-time"] == stored_upload_times[older_wheel.name]
+        assert newer_file["upload-time"] == stored_upload_times[newer_wheel.name]
+        older_time = datetime.fromisoformat(
+            older_file["upload-time"].replace("Z", "+00:00")
+        )
+        newer_time = datetime.fromisoformat(
+            newer_file["upload-time"].replace("Z", "+00:00")
+        )
         assert older_time.tzinfo == UTC
         assert newer_time.tzinfo == UTC
         assert older_time < newer_time
@@ -545,16 +523,13 @@ def test_twine_upload_json_upload_times_drive_uv_exclude_newer(tmp_path):
         index_url = f"{build_url(install_srv.port)}/simple/"
         allow_host = f"localhost:{install_srv.port}"
 
-        strict_env = tmp_path / "strict-env"
-        install_with_uv(
-            strict_env,
-            package,
+        assert uv_install_version(
+            "strict-env",
             index_url,
             allow_host,
             exclude_newer=cutoff,
-        )
-        assert installed_version(strict_env, package) == older_version
+        ) == older_version
 
-        open_env = tmp_path / "open-env"
-        install_with_uv(open_env, package, index_url, allow_host)
-        assert installed_version(open_env, package) == newer_version
+        assert (
+            uv_install_version("open-env", index_url, allow_host) == newer_version
+        )

--- a/tests/test_upload_time.py
+++ b/tests/test_upload_time.py
@@ -1,0 +1,53 @@
+from __future__ import annotations
+
+import json
+from datetime import UTC, datetime
+
+from pypiserver.upload_time import (
+    SIDECAR_NAME,
+    fallback_upload_time,
+    load_upload_times,
+    normalize_upload_time_key,
+    save_upload_times,
+)
+
+
+def test_normalize_upload_time_key_uses_root_relative_unix_style(tmp_path):
+    package = tmp_path / "nested" / "pkg-1.0.tar.gz"
+    package.parent.mkdir()
+    package.touch()
+
+    expected = "nested/pkg-1.0.tar.gz"
+
+    assert normalize_upload_time_key(tmp_path, package) == expected
+
+
+def test_save_and_load_upload_times_round_trip(tmp_path):
+    package = tmp_path / "subdir" / "pkg-1.0.tar.gz"
+    package.parent.mkdir()
+    package.touch()
+    expected = datetime(2026, 4, 3, 10, 11, 12, 345678, tzinfo=UTC)
+
+    save_upload_times(
+        tmp_path,
+        {normalize_upload_time_key(tmp_path, package): expected},
+    )
+
+    sidecar_path = tmp_path / SIDECAR_NAME
+    assert json.loads(sidecar_path.read_text(encoding="utf-8")) == {
+        "subdir/pkg-1.0.tar.gz": "2026-04-03T10:11:12.345678Z"
+    }
+    assert load_upload_times(tmp_path) == {"subdir/pkg-1.0.tar.gz": expected}
+
+
+def test_fallback_upload_time_uses_file_mtime_as_utc_datetime(tmp_path):
+    package = tmp_path / "pkg-1.0.tar.gz"
+    package.touch()
+    expected = datetime(2026, 4, 3, 10, 11, 12, 345678, tzinfo=UTC)
+    timestamp = expected.timestamp()
+
+    import os
+
+    os.utime(package, (timestamp, timestamp))
+
+    assert fallback_upload_time(package) == expected

--- a/tests/test_upload_time.py
+++ b/tests/test_upload_time.py
@@ -40,6 +40,22 @@ def test_save_and_load_upload_times_round_trip(tmp_path):
     assert load_upload_times(tmp_path) == {"subdir/pkg-1.0.tar.gz": expected}
 
 
+def test_save_upload_times_removes_sidecar_when_metadata_is_empty(tmp_path):
+    package = tmp_path / "pkg-1.0.tar.gz"
+    package.touch()
+    save_upload_times(
+        tmp_path,
+        {normalize_upload_time_key(tmp_path, package): datetime(2026, 4, 3, tzinfo=UTC)},
+    )
+
+    sidecar_path = tmp_path / SIDECAR_NAME
+    assert sidecar_path.exists()
+
+    save_upload_times(tmp_path, {})
+
+    assert not sidecar_path.exists()
+
+
 def test_fallback_upload_time_uses_file_mtime_as_utc_datetime(tmp_path):
     package = tmp_path / "pkg-1.0.tar.gz"
     package.touch()


### PR DESCRIPTION
This change makes pypiserver expose the upload-time metadata that `uv --exclude-newer` needs in order to make correct time-based candidate decisions for packages hosted by pypiserver.

Closes #690

## Summary

- persist upload-time metadata when files are uploaded
- attach upload-time to discovered packages, with mtime fallback when metadata is absent
- expose `files[].upload-time` and `versions` from `/simple/<project>/` JSON responses
- add an end-to-end `twine -> pypiserver -> uv --exclude-newer` test
- bump the Docker base image to Python 3.12 / Alpine 3.23

## Why

Public PyPI already exposes file-level upload timestamps, but private packages hosted by pypiserver did not. That meant `uv exclude-newer` could not apply the same cutoff policy to internal artifacts served by pypiserver.

This patch closes that gap with the smallest Simple API surface needed for uv.

## Test plan

- `pytest tests/test_upload_time.py tests/test_backend.py tests/test_app.py -v`
- `pytest tests/test_server.py -k twine_upload_json_upload_times_drive_uv_exclude_newer -vv`
- `python -m tox -e py`