### PR TITLE
docs: clarify Dockerfile CMD/ENTRYPOINT arg parsing for -P and friends

### DIFF
--- a/README.md
+++ b/README.md
@@ -558,6 +558,28 @@ You can also specify **pypiserver** to run as a Docker service using a
 composefile. An example composefile is provided as
 [`docker-compose.yaml`](./docker-compose.yml)
 
+#### Passing Arguments via Dockerfile CMD or ENTRYPOINT
+
+When wrapping **pypiserver** in your own image, pass each option and its value
+as **separate elements** of the CMD or ENTRYPOINT array. Docker treats every
+array element as a single argument, so `"-P /data/.htpasswd"` is parsed as
+**one** option named `-P /data/.htpasswd`, not as `-P` followed by a path —
+which makes the file lookup fail at startup.
+
+```dockerfile
+# Correct: each token is its own array element
+CMD ["pypi-server", "run", "-p", "8080", "-P", ".htpasswd", "-a", "update", "/data/packages"]
+```
+
+```dockerfile
+# Incorrect: -p, -P, and -a values are glued to their flags
+CMD ["pypi-server", "run", "-p 8080", "-P .htpasswd", "-a update", "/data/packages"]
+```
+
+The `docker run` examples above work without quoting because the host shell
+splits the command line on whitespace before Docker ever sees it; this only
+matters inside `Dockerfile` arrays.
+
 ## Alternative Installation Methods
 
 When trying the methods below, first use the following command to check whether


### PR DESCRIPTION
## What changed

`README.md` — added a "Passing Arguments via Dockerfile CMD or ENTRYPOINT" subsection to "Using the Docker Image" that explains why `-P /path/to/.htpasswd` (and similar option-with-value pairs) needs to be split into two separate array elements when wrapping pypiserver inside a downstream Dockerfile. Includes side-by-side correct/incorrect CMD examples and a note that `docker run …` on the host CLI is not affected because the shell does the splitting before Docker sees the command.

Closes #261

## Why

The reporter hit `pypi-server` failing to start under their Kubernetes Dockerfile because the CMD was written as `["pypi-server", "-p 8080", "-P /root/packages/.htaccess", ...]`. Each array element became a single argv, so `-P /root/packages/.htaccess` was parsed as one giant option name and pypi-server couldn't find the htpasswd file. The maintainer (mplanchard) confirmed this is Docker exec-form parsing behavior and said: "I'm happy to accept a docs PR that makes this clearer for people!"

Putting the note in README.md immediately after the existing `docker run -p 80:8080 ... -P .htpasswd packages` example targets exactly the audience that tripped over this — readers who are looking at the Docker section, copy a working one-liner, then build their own Dockerfile and find that the same string doesn't work.

I deliberately kept the change narrow:

- No code or tests changed; the runtime behavior is correct (it's a Docker quoting convention, not a pypiserver bug).
- Did not touch the `-P` / `-a` `--help` strings in `pypiserver/config.py` — those examples are direct CLI usage where the parsing is fine; layering a Docker-specific caveat in there would be confusing for non-Docker users.
- Did not introduce a new doc page; existing `## Using the Docker Image` is the right home.

## Verification

- `git diff README.md` is +22 / -0, all inside the existing Docker section.
- The two CMD code blocks are valid Dockerfile syntax (verified by hand-parsing — the "incorrect" example is *exactly* what the issue reporter wrote, so the contrast lands).
- `pypi-server` itself uses `argparse`, which is unaffected by this docs change; no behavior change to assert against.
