### PR TITLE
fix: harden /RPC2 XML parser against entity-expansion DoS (#685)

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,11 @@ Changelog
 3.0.0 (tbd)
 -----------
 
+- FIX: security: harden ``/RPC2`` XML parser against entity-expansion DoS
+  ("billion laughs", CWE-776). Switch from ``xml.dom.minidom`` to
+  ``defusedxml.minidom`` and reject malformed/unsafe XML payloads with
+  HTTP 400 (#685).
+
 2.4.1 (2026-02-10)
 --------------------------
 

--- a/pypiserver/_app.py
+++ b/pypiserver/_app.py
@@ -2,13 +2,16 @@ import logging
 import mimetypes
 import os
 import re
-import xml.dom.minidom
 import xmlrpc.client as xmlrpclib
 import zipfile
 from collections import defaultdict, namedtuple
 from io import BytesIO
 from json import dumps
 from urllib.parse import quote, urljoin, urlparse
+from xml.parsers.expat import ExpatError
+
+import defusedxml.minidom
+from defusedxml.common import DefusedXmlException
 
 from pypiserver.config import RunConfig
 
@@ -233,7 +236,10 @@ def pep_503_redirects(project=None):
 @auth("list")
 def handle_rpc():
     """Handle pip-style RPC2 search requests"""
-    parser = xml.dom.minidom.parse(request.body)
+    try:
+        parser = defusedxml.minidom.parse(request.body)
+    except (DefusedXmlException, ExpatError):
+        raise HTTPError(400, "Invalid or unsafe XML payload")
     methodname = (
         parser.getElementsByTagName("methodName")[0]
         .childNodes[0]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,6 +43,7 @@ license = { file = "LICENSE.txt" }
 # --- Dependencies ---
 
 dependencies = [
+  "defusedxml>=0.7.1",
   "importlib-resources>=6.5.2 ; python_full_version >= '3.10' and python_full_version < '3.12'",
   "legacy-cgi>=2.6.4 ; python_full_version >= '3.13'",
   "packaging>=26.0",

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -648,6 +648,43 @@ def test_search(root, testapp, search_xml, pkgs, matches):
             assert returned["version"] in [match[1] for match in matches]
 
 
+@pytest.mark.parametrize(
+    "payload",
+    [
+        # Billion-laughs / entity-expansion DoS (issue #685).
+        '<?xml version="1.0"?>'
+        "<!DOCTYPE lolz ["
+        '  <!ENTITY lol "AAAAAAAAAA">'
+        '  <!ENTITY lol2 "&lol;&lol;&lol;&lol;&lol;&lol;&lol;&lol;&lol;&lol;">'
+        '  <!ENTITY lol3 "&lol2;&lol2;&lol2;&lol2;&lol2;&lol2;&lol2;&lol2;&lol2;&lol2;">'
+        "]>"
+        "<methodCall><methodName>search</methodName>"
+        "<params><param><value><string>&lol3;</string></value></param></params>"
+        "</methodCall>",
+        # External entity (XXE) attempting local file read.
+        '<?xml version="1.0"?>'
+        '<!DOCTYPE foo [<!ENTITY xxe SYSTEM "file:///etc/passwd">]>'
+        "<methodCall><methodName>search</methodName>"
+        "<params><param><value><string>&xxe;</string></value></param></params>"
+        "</methodCall>",
+        # Plain malformed XML.
+        "<not-xml",
+    ],
+)
+def test_rpc_rejects_unsafe_or_invalid_xml(testapp, payload):
+    """Unsafe (DTD/entity) and malformed XML must be rejected with 400.
+
+    Regression test for issue #685 (CWE-776 entity expansion DoS in /RPC2).
+    """
+    resp = testapp.post(
+        "/RPC2",
+        payload,
+        headers={"Content-Type": "text/xml"},
+        expect_errors=True,
+    )
+    assert resp.status_int == 400
+
+
 class TestRemovePkg:
     """The API allows removal of packages."""
 

--- a/uv.lock
+++ b/uv.lock
@@ -430,6 +430,15 @@ wheels = [
 ]
 
 [[package]]
+name = "defusedxml"
+version = "0.7.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/0f/d5/c66da9b79e5bdb124974bfe172b4daf3c984ebd9c2a06e2b8a4dc7331c72/defusedxml-0.7.1.tar.gz", hash = "sha256:1bb3032db185915b62d7c6209c5a8792be6a32ab2fedacc84e01b52c51aa3e69", size = 75520, upload-time = "2021-03-08T10:59:26.269Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/07/6c/aa3f2f849e01cb6a001cd8554a88d4c77c5c1a31c95bdf1cf9301e6d9ef4/defusedxml-0.7.1-py2.py3-none-any.whl", hash = "sha256:a352e7e428770286cc899e2542b6cdaedb2b4953ff269a210103ec58f6198a61", size = 25604, upload-time = "2021-03-08T10:59:24.45Z" },
+]
+
+[[package]]
 name = "docopt"
 version = "0.6.2"
 source = { registry = "https://pypi.org/simple" }
@@ -1073,6 +1082,7 @@ wheels = [
 name = "pypiserver"
 source = { editable = "." }
 dependencies = [
+    { name = "defusedxml" },
     { name = "importlib-resources", marker = "python_full_version < '3.12'" },
     { name = "legacy-cgi", marker = "python_full_version >= '3.13'" },
     { name = "packaging" },
@@ -1121,6 +1131,7 @@ test = [
 
 [package.metadata]
 requires-dist = [
+    { name = "defusedxml", specifier = ">=0.7.1" },
     { name = "importlib-resources", marker = "python_full_version >= '3.10' and python_full_version < '3.12'", specifier = ">=6.5.2" },
     { name = "legacy-cgi", marker = "python_full_version >= '3.13'", specifier = ">=2.6.4" },
     { name = "packaging", specifier = ">=26.0" },


### PR DESCRIPTION
## Summary

Fixes #685 (CWE-776, billion-laughs / entity-expansion DoS in the unauthenticated `/RPC2` search endpoint).

The endpoint parsed request bodies with `xml.dom.minidom.parse()`, which the [Python stdlib docs explicitly mark as unsafe](https://docs.python.org/3/library/xml.html#xml-vulnerabilities) against maliciously constructed input. Combined with the default-anonymous `list` action (the `@auth(\"list\")` decorator only enforces auth when `\"list\"` is in `config.authenticate`, and the default is `[\"update\"]`), a ~700-byte DTD payload triggers either an Expat amplification error (HTTP 500) on Expat ≥ 2.4.0 or uncapped exponential entity expansion (OOM) on older Expat — and many long-lived base images still ship Expat 2.2.x.

## Fix

- Switch from `xml.dom.minidom` to `defusedxml.minidom`, which rejects internal entity bombs, external entities (XXE), and DTD-based attacks by default.
- Convert the resulting `DefusedXmlException` / `ExpatError` into a clean HTTP 400 instead of an unhandled 500.
- Add `defusedxml >= 0.7.1` as a runtime dep. `defusedxml` is the canonical XML-hardening library recommended by the Python stdlib docs, ~25 KB, pure-Python, stable since 2013, no further transitive deps.

I also considered a no-new-dep variant (rejecting `<!DOCTYPE` / `<!ENTITY` at the wire — valid since XML-RPC doesn't use DTDs). Happy to switch to that on request if the dep is undesirable; defusedxml seemed the cleaner default since it's the standard fix recommended for exactly this CWE.

## Reproduction

Before this change (Python 3.11 / Expat 2.7.3):

```bash
curl -X POST http://localhost:8080/RPC2 \
  -H 'Content-Type: text/xml' \
  --data @level7-billion-laughs.xml
# HTTP/1.1 500 Internal Server Error
# ExpatError: limit on input amplification factor (from DTD and entities) breached
```

On a Python linked against Expat < 2.4.0 (e.g. RHEL 8 with system Expat 2.2.5, or many older container images), the same request triggers full exponential expansion → OOM.

After this change: HTTP 400 with body `Invalid or unsafe XML payload`, returned in microseconds without any expansion attempt.

## Tests

- Added `test_rpc_rejects_unsafe_or_invalid_xml` covering three payloads:
  - billion-laughs DTD (the original PoC, shortened),
  - XXE attempting `file:///etc/passwd` exfiltration,
  - plain malformed XML.
- Existing `test_search` (parametrized, 6 cases) still passes — no regression on the legitimate search code path.

```
tests/test_app.py ........................................................... 169 passed
```

(The `tests/test_server.py` integration suite has pre-existing failures unrelated to this change — `python -m build --wheel --no-isolation` returns 256 on `main` as well.)
